### PR TITLE
Continue with forward proxy if ReverseOnly is not true and no mapping available

### DIFF
--- a/src/reqs.c
+++ b/src/reqs.c
@@ -369,14 +369,14 @@ BAD_REQUEST_ERROR:
 
                 reverse_url = reverse_rewrite_url (connptr, hashofheaders, url);
 
-                if (!reverse_url && config.reverseonly) {
-                        goto fail;
-                }
-
-                /* if not reverse only and a mapping was found.. */
-                if(reverse_url) {
+                if (reverse_url != NULL) {
                         safefree (url);
                         url = reverse_url;
+		} else if (config.reverseonly) {
+                        indicate_http_error (connptr, 400, "Bad Request",
+                                     "detail", "No mapping found for requested url",
+                                     "url", url, NULL);
+                        goto fail;
                 }
         }
 #endif

--- a/src/reqs.c
+++ b/src/reqs.c
@@ -369,12 +369,15 @@ BAD_REQUEST_ERROR:
 
                 reverse_url = reverse_rewrite_url (connptr, hashofheaders, url);
 
-                if (!reverse_url) {
+                if (!reverse_url && config.reverseonly) {
                         goto fail;
                 }
 
-                safefree (url);
-                url = reverse_url;
+                /* if not reverse only and a mapping was found.. */
+                if(reverse_url) {
+                        safefree (url);
+                        url = reverse_url;
+                }
         }
 #endif
 

--- a/src/reverse-proxy.c
+++ b/src/reverse-proxy.c
@@ -166,7 +166,8 @@ char *reverse_rewrite_url (struct conn_s *connptr, hashmap_t hashofheaders,
                 return NULL;
         }
 
-        log_message (LOG_CONN, "Rewriting URL: %s -> %s", url, rewrite_url);
+        log_message (LOG_CONN, "Rewriting URL: %s -> %s", url, 
+			rewrite_url ? rewrite_url : "No mapping found");
 
         /* Store reverse path so that the magical tracking cookie can be set */
         if (config.reversemagic && reverse)


### PR DESCRIPTION
Hi,

This pull request has a patch to avoid premature failure if tinyproxy is configured as both a Reverse and Forward Proxy with ReverseOnly is Off. 

If no mapping is found, the code now continues with the original url (possibly filtering it later).

Also a null dereference in log_message is avoided.

Kind regards,
Stephan