### PR TITLE
Add upstream proxy basic authentication

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -254,8 +254,8 @@ struct {
                 BEGIN "(no" WS "upstream)" WS STR END, handle_upstream_no, NULL
         },
         {
-                BEGIN "(upstream)" WS "(" IP "|" ALNUM ")" ":" INT "(" WS STR
-                      ")?" END, handle_upstream, NULL
+                BEGIN "(upstream)" WS "(" STR "@" ")?" "(" IP "|" ALNUM ")" ":"
+                        INT "(" WS STR ")?" END, handle_upstream, NULL
         },
 #endif
         /* loglevel */
@@ -1075,22 +1075,31 @@ static HANDLE_FUNC (handle_upstream)
         char *ip;
         int port;
         char *domain;
+        char *basic_auth = NULL;        /* optional, Base64 basic auth */
 
-        ip = get_string_arg (line, &match[2]);
+        if (match[3].rm_so != -1) {
+                /* Basic auth is set for upstream proxy. */
+                basic_auth = get_string_arg (line, &match[3]);
+        }
+
+        ip = get_string_arg (line, &match[4]);
         if (!ip)
                 return -1;
-        port = (int) get_long_arg (line, &match[7]);
+        port = (int) get_long_arg (line, &match[9]);
 
-        if (match[10].rm_so != -1) {
-                domain = get_string_arg (line, &match[10]);
+        if (match[12].rm_so != -1) {
+                domain = get_string_arg (line, &match[12]);
                 if (domain) {
-                        upstream_add (ip, port, domain, &conf->upstream_list);
+                        upstream_bauth_add (ip, port, basic_auth, domain,
+                                            &conf->upstream_list);
                         safefree (domain);
                 }
         } else {
-                upstream_add (ip, port, NULL, &conf->upstream_list);
+                upstream_bauth_add (ip, port, basic_auth, NULL,
+                                    &conf->upstream_list);
         }
 
+        safefree (basic_auth);
         safefree (ip);
 
         return 0;

--- a/src/conf.c
+++ b/src/conf.c
@@ -1090,13 +1090,12 @@ static HANDLE_FUNC (handle_upstream)
         if (match[12].rm_so != -1) {
                 domain = get_string_arg (line, &match[12]);
                 if (domain) {
-                        upstream_bauth_add (ip, port, basic_auth, domain,
-                                            &conf->upstream_list);
+                        upstream_add (ip, port, basic_auth, domain,
+                                      &conf->upstream_list);
                         safefree (domain);
                 }
         } else {
-                upstream_bauth_add (ip, port, basic_auth, NULL,
-                                    &conf->upstream_list);
+                upstream_add (ip, port, basic_auth, NULL, &conf->upstream_list);
         }
 
         safefree (basic_auth);
@@ -1113,7 +1112,7 @@ static HANDLE_FUNC (handle_upstream_no)
         if (!domain)
                 return -1;
 
-        upstream_add (NULL, 0, domain, &conf->upstream_list);
+        upstream_add (NULL, 0, NULL, domain, &conf->upstream_list);
         safefree (domain);
 
         return 0;

--- a/src/reqs.c
+++ b/src/reqs.c
@@ -267,6 +267,17 @@ establish_http_connection (struct conn_s *connptr, struct request_s *request)
                                       "Connection: close\r\n",
                                       request->method, request->path,
                                       request->host, portbuff);
+        } else if ((connptr->upstream_proxy) &&
+                (connptr->upstream_proxy->basic_auth)) {
+                /* Basic auth is set for upstream proxy. */
+                return write_message (connptr->server_fd,
+                                      "%s %s HTTP/1.0\r\n"
+                                      "Host: %s%s\r\n"
+                                      "Connection: close\r\n"
+                                      "Proxy-Authorization: Basic %s\r\n",
+                                      request->method, request->path,
+                                      request->host, portbuff,
+                                      connptr->upstream_proxy->basic_auth);
         } else {
                 return write_message (connptr->server_fd,
                                       "%s %s HTTP/1.0\r\n"

--- a/src/upstream.c
+++ b/src/upstream.c
@@ -30,8 +30,7 @@
 
 #ifdef UPSTREAM_SUPPORT
 /**
- * Construct an upstream struct from input data, with basic auth credentials.
- * 'basic_auth' can be NULL.
+ * Construct an upstream struct from input data.
  */
 static struct upstream *upstream_build (const char *host, int port,
                                         const char *basic_auth,
@@ -126,11 +125,10 @@ fail:
 }
 
 /*
- * Add an entry to the upstream list, with basic auth credentials.
- * 'basic_auth' can be NULL.
+ * Add an entry to the upstream list.
  */
-void upstream_bauth_add (const char *host, int port, const char *basic_auth,
-                         const char *domain, struct upstream **upstream_list)
+void upstream_add (const char *host, int port, const char *basic_auth,
+                   const char *domain, struct upstream **upstream_list)
 {
         struct upstream *up;
 
@@ -171,15 +169,6 @@ upstream_cleanup:
         safefree (up);
 
         return;
-}
-
-/*
- * Add an entry to the upstream list
- */
-void upstream_add (const char *host, int port, const char *domain,
-                   struct upstream **upstream_list)
-{
-        upstream_bauth_add (host, port, NULL, domain, upstream_list);
 }
 
 /*

--- a/src/upstream.h
+++ b/src/upstream.h
@@ -36,12 +36,16 @@ struct upstream {
         char *domain;           /* optional */
         char *host;
         int port;
+        char *basic_auth;       /* optional, Base64 basic auth */
         in_addr_t ip, mask;
 };
 
 #ifdef UPSTREAM_SUPPORT
 extern void upstream_add (const char *host, int port, const char *domain,
                           struct upstream **upstream_list);
+extern void upstream_bauth_add (const char *host, int port,
+                                const char *basic_auth, const char *domain,
+                                struct upstream **upstream_list);
 extern struct upstream *upstream_get (char *host, struct upstream *up);
 extern void free_upstream_list (struct upstream *up);
 #endif /* UPSTREAM_SUPPORT */

--- a/src/upstream.h
+++ b/src/upstream.h
@@ -41,11 +41,9 @@ struct upstream {
 };
 
 #ifdef UPSTREAM_SUPPORT
-extern void upstream_add (const char *host, int port, const char *domain,
+extern void upstream_add (const char *host, int port,
+                          const char *basic_auth, const char *domain,
                           struct upstream **upstream_list);
-extern void upstream_bauth_add (const char *host, int port,
-                                const char *basic_auth, const char *domain,
-                                struct upstream **upstream_list);
 extern struct upstream *upstream_get (char *host, struct upstream *up);
 extern void free_upstream_list (struct upstream *up);
 #endif /* UPSTREAM_SUPPORT */


### PR DESCRIPTION
This pull request aims to add a very nice functionality to Tinyproxy: basic authentication support for upstream proxies.

These files have changes:
- `conf.c`: changed the upstream directive to indicate a Base64 authentication string for using with the proxy, in the form of `"Base64auth"@proxy.com:8000`.
- `reqs.c`: added `Proxy-Authorization` header when establishing a HTTP connection with an upstream proxy that has basic auth enabled.
- `upstream.h`: added new field to the `upstream` struct, changed `upstream_add()` prototype.
- `upstream.c`: changed `upstream_build()`, `upstream_add()`, and `free_upstream_list()`.

This means that when inserting a line like `Upstream "abcABC"@proxy.com:8000` in the config file, Tinyproxy will use `abcABC` as the authentication credentials when connecting to `proxy.com`. Note that these credentials should be the string `user:password` encoded as a Base64 string.

Some questions / improvements:
- `upstream.c`:
  - `upstream_build()`: should the Base64 credentials be logged?
- `reqs.c`:
  - `establish_http_connection()`: is this the correct place for the `Proxy-Authorization` header to be sent?
- `conf.c`: I know it would be better to accept the credentials in the `user:password` style, instead of a plain Base64 string. However this implies:
  - Using a external library for Base64 encoding, like [libb64](http://libb64.sourceforge.net/).
  - Or, coding a Base64-enconding function into Tinyproxy (for example, in `utils.c`).
  - At this moment, I prefered not to include any Base64-encoding code into Tinyproxy, so you can store the proxy credentials in Base64 in the config file. I understand that the `user:password` style may be more "user-friendly".
- The man docs should be updated.
