### PR TITLE
Fix OS X build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -240,8 +240,6 @@ AC_SUBST(LIBS)
 AC_SUBST(ADDITIONAL_OBJECTS)
 
 # Check for xml tools
-AC_PATH_PROG(XMLLINT, xmllint, no)
-AM_CONDITIONAL(HAVE_XMLLINT, test "x$XMLLINT" != "xno")
 AC_PATH_PROG(XSLTPROC, xsltproc, no)
 AM_CONDITIONAL(HAVE_XSLTPROC, test "x$XSLTPROC" != "xno")
 
@@ -251,6 +249,21 @@ AM_CONDITIONAL(HAVE_A2X, test "x$A2X" != "xno")
 if test x"$A2X" = x"no"; then
   AC_MSG_ERROR([Test for asciidoc failed. See the file 'INSTALL' for help.])
 fi
+
+# checking xmllint
+AC_PATH_PROG(XMLLINT, xmllint, no)
+if test "x$XMLLINT" != "xno"; then
+  AS_ECHO_N("testing xmllint... ")
+  echo "TEST" > conftest.txt
+  if $A2X -f docbook conftest.txt 2>/dev/null; then
+    AS_ECHO("ok")
+  else
+    AS_ECHO("failed")
+    XMLLINT="no"
+  fi
+  rm -f conftest.txt conftest.xml
+fi
+AM_CONDITIONAL(HAVE_XMLLINT, test "x$XMLLINT" != "xno")
 
 AC_CONFIG_FILES([
 Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -219,7 +219,12 @@ if test x"$debug_enabled" != x"yes" ; then
     CFLAGS="-DNDEBUG $CFLAGS"
 fi
 
+AS_ECHO_N(["checking to see if linker understands -z,defs... "])
+LDFLAGS_OLD="-Wl $LDFLAGS"
 LDFLAGS="-Wl,-z,defs $LDFLAGS"
+AC_LINK_IFELSE([AC_LANG_PROGRAM()],
+    AS_ECHO("yes"),
+    AS_ECHO("no"); LDFLAGS="$LDFLAGS_OLD")
 
 dnl
 dnl Make sure we can actually handle the "--with-*" and "--enable-*" stuff.

--- a/docs/man5/Makefile.am
+++ b/docs/man5/Makefile.am
@@ -1,9 +1,11 @@
 MAN5_FILES  = \
 	tinyproxy.conf.txt
 
-A2X_ARGS = \
-	-d manpage \
-	-f manpage
+if HAVE_XMLLINT
+A2X_ARGS = -d manpage -f manpage
+else
+A2X_ARGS = -d manpage -f manpage -L
+endif
 
 man_MANS = \
 	$(MAN5_FILES:.txt=.5)

--- a/docs/man8/Makefile.am
+++ b/docs/man8/Makefile.am
@@ -1,9 +1,11 @@
 MAN8_FILES = \
 	tinyproxy.txt
 
-A2X_ARGS = \
-	-d manpage \
-	-f manpage
+if HAVE_XMLLINT
+A2X_ARGS = -d manpage -f manpage
+else
+A2X_ARGS = -d manpage -f manpage -L
+endif
 
 man_MANS = \
 	$(MAN8_FILES:.txt=.8)


### PR DESCRIPTION
Copied some build fixes from Homebrew and moved lookup_variable from html-error.c to hashmap.c so it can be used elsewhere.