### PR TITLE
Prevent child from calling exit() on interrupt

### DIFF
--- a/src/child.c
+++ b/src/child.c
@@ -233,6 +233,9 @@ static void child_main (struct child_s *ptr)
 
                 ret = select(maxfd + 1, &rfds, NULL, NULL, NULL);
                 if (ret == -1) {
+                        if (errno == EINTR) {
+                                continue;
+                        }
                         log_message (LOG_ERR, "error calling select: %s",
                                      strerror(errno));
                         exit(1);


### PR DESCRIPTION
A proposed fix for the logrotate SIGHUP issue.