### PR TITLE
src/Makefile.am: fix spaces vs TAB

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -62,7 +62,7 @@ authors.c: $(top_srcdir)/authors.xml $(srcdir)/authors.xsl
 if HAVE_XSLTPROC
 	$(AM_V_GEN) $(XSLTPROC) $(srcdir)/authors.xsl $< > $(@) || rm -f $(@)
 else
-        @echo "*** xsltproc is required to regenerate $(@) ***"; exit 1;
+	@echo "*** xsltproc is required to regenerate $(@) ***"; exit 1;
 endif
 
 BUILT_SOURCES = \


### PR DESCRIPTION
this causes a build failure on several platforms using older versions
of autotools or GNU make.

make[2]: Entering directory `src'
Makefile:670: *** missing separator (did you mean TAB instead of 8 spaces?).  Stop.
make[2]: Leaving directory `src'

fixes #72