### PR TITLE
Add support for 'X-Forwarded-For' header

### DIFF
--- a/docs/man5/tinyproxy.conf.txt.in
+++ b/docs/man5/tinyproxy.conf.txt.in
@@ -246,6 +246,14 @@ AddHeader "X-My-Header" "Powered by Tinyproxy"
     enabling this option, you break compliance.
     Don't disable the `Via` header unless you know what you are doing...
 
+*DisableXffHeader*::
+
+    The 'X-Forwarded-For' header isn't required by the HTTP RFC,
+    but is a common method for identifying the originating IP address
+    of a client connecting to a web server through an HTTP proxy or
+    load balancer. Though, using this is a security concern.
+    So turn this off only for demand.
+
 *Filter*::
 
     Tinyproxy supports filtering of web sites based on URLs or

--- a/etc/tinyproxy.conf.in
+++ b/etc/tinyproxy.conf.in
@@ -234,6 +234,15 @@ ViaProxyName "tinyproxy"
 #DisableViaHeader Yes
 
 #
+# DisableXffHeader: The 'X-Forwarded-For' header isn't required by the
+# HTTP RFC, but is a common method for identifying the originating
+# IP address of a client connecting to a web server through an HTTP
+# proxy or load balancer. Though, using this is a security concern.
+# So we disable it by default.
+#
+DisableXffHeader Yes
+
+#
 # Filter: This allows you to specify the location of the filter file.
 #
 #Filter "@pkgsysconfdir@/filter"

--- a/src/conf.c
+++ b/src/conf.c
@@ -156,6 +156,7 @@ static HANDLE_FUNC (handle_timeout);
 static HANDLE_FUNC (handle_user);
 static HANDLE_FUNC (handle_viaproxyname);
 static HANDLE_FUNC (handle_disableviaheader);
+static HANDLE_FUNC (handle_disablexffheader);
 static HANDLE_FUNC (handle_xtinyproxy);
 
 #ifdef UPSTREAM_SUPPORT
@@ -205,11 +206,12 @@ struct {
         STDCONF ("defaulterrorfile", STR, handle_defaulterrorfile),
         STDCONF ("statfile", STR, handle_statfile),
         STDCONF ("stathost", STR, handle_stathost),
-        STDCONF ("xtinyproxy",  BOOL, handle_xtinyproxy),
         /* boolean arguments */
         STDCONF ("syslog", BOOL, handle_syslog),
         STDCONF ("bindsame", BOOL, handle_bindsame),
         STDCONF ("disableviaheader", BOOL, handle_disableviaheader),
+        STDCONF ("disablexffheader", BOOL, handle_disablexffheader),
+        STDCONF ("xtinyproxy",  BOOL, handle_xtinyproxy),
         /* integer arguments */
         STDCONF ("port", INT, handle_port),
         STDCONF ("maxclients", INT, handle_maxclients),
@@ -733,6 +735,19 @@ static HANDLE_FUNC (handle_disableviaheader)
 
         log_message (LOG_INFO,
                      "Disabling transmission of the \"Via\" header.");
+        return 0;
+}
+
+static HANDLE_FUNC (handle_disablexffheader)
+{
+        int r = set_bool_arg (&conf->disable_xffheader, line, &match[2]);
+
+        if (r) {
+                return r;
+        }
+
+        log_message (LOG_INFO,
+                     "Disabling transmission of the \"X-Forwarded-For\" header.");
         return 0;
 }
 

--- a/src/conf.h
+++ b/src/conf.h
@@ -77,6 +77,8 @@ struct config_s {
 
         unsigned int disable_viaheader; /* boolean */
 
+        unsigned int disable_xffheader; /* boolean */
+
         /*
          * Error page support.  Map error numbers to file paths.
          */

--- a/src/reqs.c
+++ b/src/reqs.c
@@ -823,6 +823,35 @@ done:
 }
 
 /*
+ * Create a 'X-Forwarded-For' header or append to the existing one.
+ * It isn't standard, but is a common method for identifying the originating 
+ * IP address of a client.
+ */
+static int
+write_xff_header(int fd, hashmap_t hashofheaders,
+                     char* client_ip_addr)
+{
+        ssize_t len;
+        char *data;
+        int ret;
+
+        len = hashmap_entry_by_key(hashofheaders, "x-forwarded-for", (void **)&data);
+        if (len > 0) {
+                ret = write_message(fd,
+                                    "X-Forwarded-For: %s, %s\r\n",
+                                    data, client_ip_addr);
+
+                hashmap_remove(hashofheaders, "x-forwarded-for");
+        } else {
+                ret = write_message(fd,
+                                    "X-Forwarded-For: %s\r\n",
+                                    client_ip_addr);
+        }
+
+        return ret;
+}
+
+/*
  * Number of buckets to use internally in the hashmap.
  */
 #define HEADER_BUCKETS 256
@@ -892,6 +921,18 @@ process_client_headers (struct conn_s *connptr, hashmap_t hashofheaders)
                                      "A network error occurred while "
                                      "trying to write data to the remote web server.",
                                      NULL);
+                goto PULL_CLIENT_DATA;
+        }
+        /* Send new or appended the 'X-Forwarded-For' header */
+        ret = write_xff_header(connptr->server_fd, hashofheaders,
+                               connptr->client_ip_addr);
+        if (ret < 0) {
+                indicate_http_error(connptr, 503,
+                                    "Could not send data to remote server",
+                                    "detail",
+                                    "A network error occurred while "
+                                    "trying to write data to the remote web server.",
+                                    NULL);
                 goto PULL_CLIENT_DATA;
         }
 
@@ -1053,6 +1094,11 @@ retry:
         ret = write_via_header (connptr->client_fd, hashofheaders,
                                 connptr->protocol.major,
                                 connptr->protocol.minor);
+        if (ret < 0)
+                goto ERROR_EXIT;
+        /* Send new or appended the 'X-Forwarded-For' header */
+        ret = write_xff_header(connptr->client_fd, hashofheaders,
+                               connptr->server_ip_addr);
         if (ret < 0)
                 goto ERROR_EXIT;
 


### PR DESCRIPTION
Usually people care about privacy and anonymity on the Internet, so proxy software is frequently used to filter out or mange several headers, to hide client's identity. But sometimes situation is completely different and one needs to tell the server about client's real address. Here comes a 'X-Forwarded-For' header that was introduced by the Squid caching proxy server's developers.

> The X-Forwarded-For (XFF) HTTP header field is a common method for identifying the originating IP address of a client connecting to a web server through an HTTP proxy or load balancer. [[wikipedia](https://en.wikipedia.org/wiki/X-Forwarded-For)]

'X-Tinyproxy' field serves the same target, but is much less recognized.

In a nutshell, I just mutated ```write_via_header()``` function into ```write_xff_header()```. And placed a call for it after ```write_via_header()``` in processing. I'm not 100% positive that it's correct for ```process_server_headers()``` case.

Also I added an option to the configuration file to control this. It has some description and default value that disables this feature.