### PR TITLE
Allow overriding logfile and pidfile path from command line.

### DIFF
--- a/docs/man8/tinyproxy.txt.in
+++ b/docs/man8/tinyproxy.txt.in
@@ -40,8 +40,14 @@ OPTIONS
 *-h*::
     Display a short help screen of command line arguments and exit.
 
-*-l*::
+*-L*::
     Display the licensing agreement.
+
+*-l <logfile>*::
+    Set log file path. Overrides configuration file *LogFile* directive.
+
+*-p <pidfile>*::
+    Set pidfile path. Overrides configuration file *PidFile* directive.
 
 *-v*::
     Display version information and exit.

--- a/src/conf.c
+++ b/src/conf.c
@@ -542,7 +542,7 @@ static void initialize_with_defaults (struct config_s *conf,
  * Load the configuration.
  */
 int reload_config_file (const char *config_fname, struct config_s *conf,
-                        struct config_s *defaults)
+                        struct config_s *defaults, struct config_s *overrides)
 {
         int ret;
 
@@ -580,6 +580,34 @@ int reload_config_file (const char *config_fname, struct config_s *conf,
                              "Therefore setting idle timeout to %u seconds.",
                              MAX_IDLE_TIME);
                 conf->idletimeout = MAX_IDLE_TIME;
+        }
+
+        /* Copy overridable values. */
+        if (overrides->logf_name != NULL) {
+                if (conf->logf_name != NULL) {
+                        safefree (conf->logf_name);
+                }
+                conf->logf_name = safestrdup (overrides->logf_name);
+                if (!conf->logf_name) {
+                        fprintf (stderr,
+                                 "%s: Could not allocate memory.\n",
+                                 PACKAGE);
+                        ret = -1;
+                }
+                conf->syslog = 0;
+        }
+
+        if (overrides->pidpath != NULL) {
+                if (conf->pidpath != NULL) {
+                        safefree (conf->pidpath);
+                }
+                conf->pidpath = safestrdup (overrides->pidpath);
+                if (!conf->pidpath) {
+                        fprintf (stderr,
+                                 "%s: Could not allocate memory.\n",
+                                 PACKAGE);
+                        ret = -1;
+                }
         }
 
 done:

--- a/src/conf.h
+++ b/src/conf.h
@@ -113,7 +113,7 @@ struct config_s {
 };
 
 extern int reload_config_file (const char *config_fname, struct config_s *conf,
-                               struct config_s *defaults);
+                               struct config_s *defaults, struct config_s *overrides);
 
 int config_compile_regex (void);
 


### PR DESCRIPTION
This implements half of the #43 feature request.

It allows specifying logfile and pidfile on the command line. It is useful when starting tinyproxy from a service manager, such as systemd.

The paths given on the command line always override the respective configuration file directives (that is, LogFile and PidFile), even after a SIGHUP.

A lot of daemons use flag letters `-l` and `-p` to specify those paths so I figured it would be a good idea to use the same and move license display to `-L`. I can change flags if needed, just ask.