### PR TITLE
Relax strict checking of log file.

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -70,7 +70,7 @@ static unsigned int logging_initialized = FALSE;     /* boolean */
  */
 int open_log_file (const char *log_file_name)
 {
-        log_file_fd = create_file_safely (log_file_name, FALSE);
+        log_file_fd = create_file_safely (log_file_name, FALSE, FALSE);
         return log_file_fd;
 }
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -32,6 +32,7 @@ extern int send_http_message (struct conn_s *connptr, int http_code,
 
 extern int pidfile_create (const char *path);
 extern int create_file_safely (const char *filename,
-                               unsigned int truncate_file);
+                               unsigned int truncate_file,
+                               unsigned int strict_check);
 
 #endif


### PR DESCRIPTION
Add a strict_check parameter to create_file_safely() and disable the
strict file type checking when opening the log file. This allows the log
file to be a device file, fifo, etc.

This implements part of #43.