### PR TITLE
tinyproxy.conf.in: default to allow CONNECT method more broadly

### DIFF
--- a/etc/tinyproxy.conf.in
+++ b/etc/tinyproxy.conf.in
@@ -283,12 +283,12 @@ ViaProxyName "tinyproxy"
 # ConnectPort: This is a list of ports allowed by tinyproxy when the
 # CONNECT method is used.  To disable the CONNECT method altogether, set
 # the value to 0.  If no ConnectPort line is found, all ports are
-# allowed (which is not very secure.)
+# allowed.
 #
 # The following two ports are used by SSL.
 #
-ConnectPort 443
-ConnectPort 563
+#ConnectPort 443
+#ConnectPort 563
 
 #
 # Configure one or more ReversePath directives to enable reverse proxy


### PR DESCRIPTION
tinyproxy conservatively defaulted to allow CONNECT method only
on two ports used by SSL in the ancient past, but since HTTPS usage
got much more widespread (actually, it's now the default for the
majority of websites), it makes sense now to allow it without
restriction by default to accomodate for the new situation.