### PR TITLE
allow usage without pidfile and logfile

### DIFF
--- a/etc/tinyproxy.conf.in
+++ b/etc/tinyproxy.conf.in
@@ -121,6 +121,7 @@ LogLevel Info
 #
 # PidFile: Write the PID of the main tinyproxy thread to this file so it
 # can be used for signalling purposes.
+# If not specified, no pidfile will be written.
 #
 #PidFile "@localstatedir@/run/tinyproxy/tinyproxy.pid"
 

--- a/src/log.c
+++ b/src/log.c
@@ -70,7 +70,10 @@ static unsigned int logging_initialized = FALSE;     /* boolean */
  */
 int open_log_file (const char *log_file_name)
 {
-        log_file_fd = create_file_safely (log_file_name, FALSE);
+	if (config.godaemon == FALSE)
+		log_file_fd = fileno(stdout);
+	else
+		log_file_fd = create_file_safely (log_file_name, FALSE);
         return log_file_fd;
 }
 
@@ -79,7 +82,7 @@ int open_log_file (const char *log_file_name)
  */
 void close_log_file (void)
 {
-        if (log_file_fd < 0) {
+        if (log_file_fd < 0 || log_file_fd == fileno(stdout)) {
                 return;
         }
 

--- a/src/main.c
+++ b/src/main.c
@@ -356,7 +356,7 @@ static void initialize_config_defaults (struct config_s *conf)
         conf->stathost = safestrdup (TINYPROXY_STATHOST);
         conf->idletimeout = MAX_IDLE_TIME;
         conf->logf_name = safestrdup (LOCALSTATEDIR "/log/tinyproxy/tinyproxy.log");
-        conf->pidpath = safestrdup (LOCALSTATEDIR "/run/tinyproxy/tinyproxy.pid");
+        conf->pidpath = NULL;
 }
 
 /**
@@ -496,7 +496,7 @@ main (int argc, char **argv)
         child_close_sock ();
 
         /* Remove the PID file */
-        if (unlink (config.pidpath) < 0) {
+        if (config.pidpath != NULL && unlink (config.pidpath) < 0) {
                 log_message (LOG_WARNING,
                              "Could not remove PID file \"%s\": %s.",
                              config.pidpath, strerror (errno));

--- a/src/main.c
+++ b/src/main.c
@@ -147,7 +147,7 @@ display_usage (void)
         printf ("Usage: %s [options]\n", PACKAGE);
         printf ("\n"
                 "Options are:\n"
-                "  -d        Do not daemonize (run in foreground).\n"
+                "  -d        Do not daemonize (run in foreground, log to stdout).\n"
                 "  -c FILE   Use an alternate configuration file.\n"
                 "  -h        Display this usage information.\n"
                 "  -l        Display the license.\n"


### PR DESCRIPTION
commit 1 changes the behaviour so that if no pidfile is specified in config, none is created.
this allows for running tinyproxy on an as-needed basis in foreground, without having the hassle of setting up a pidfile location.

commit 2 changes the behaviour so that if command line option -d (no-daemon, i.e. stay in foreground) is used, log output is written to stdout, so the user doesnt have to 1) set up a logfile location in config 2) needs to have writable space on the file system 3) has to open a second terminal to tail -f the logfile.

this PR makes tinyproxy behave much more unix-like and in line with other services.