### PR TITLE
safe_write/read: take void* buffer for generic use

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -32,10 +32,11 @@
  * Write the buffer to the socket. If an EINTR occurs, pick up and try
  * again. Keep sending until the buffer has been sent.
  */
-ssize_t safe_write (int fd, const char *buffer, size_t count)
+ssize_t safe_write (int fd, const void *buf, size_t count)
 {
         ssize_t len;
         size_t bytestosend;
+	const char *buffer = buf;
 
         assert (fd >= 0);
         assert (buffer != NULL);
@@ -67,7 +68,7 @@ ssize_t safe_write (int fd, const char *buffer, size_t count)
  * Matched pair for safe_write(). If an EINTR occurs, pick up and try
  * again.
  */
-ssize_t safe_read (int fd, char *buffer, size_t count)
+ssize_t safe_read (int fd, void *buffer, size_t count)
 {
         ssize_t len;
 

--- a/src/network.h
+++ b/src/network.h
@@ -21,8 +21,8 @@
 #ifndef TINYPROXY_NETWORK_H
 #define TINYPROXY_NETWORK_H
 
-extern ssize_t safe_write (int fd, const char *buffer, size_t count);
-extern ssize_t safe_read (int fd, char *buffer, size_t count);
+extern ssize_t safe_write (int fd, const void *buf, size_t count);
+extern ssize_t safe_read (int fd, void *buf, size_t count);
 
 extern int write_message (int fd, const char *fmt, ...);
 extern ssize_t readline (int fd, char **whole_buffer);


### PR DESCRIPTION
if using one of unsigned or signed char for the function prototype, one
gets nasty warnings when using it with the other type. the only proper
solution is to put void* into the prototype, and then specialize the pointer
inside the function using an automatic variable.
for exactly this reason, libc functions like read(), write(), etc use void*
too.


this is a prerequisite for getting the socks proxy support, the upstream auth, and the basic auth patches merged (to build them without warnings).