### PR TITLE
add support for basic HTTP authentication

### DIFF
--- a/etc/tinyproxy.conf.in
+++ b/etc/tinyproxy.conf.in
@@ -215,6 +215,11 @@ MaxRequestsPerChild 0
 #
 Allow 127.0.0.1
 
+# BasicAuth: HTTP "Basic Authentication" for accessing the proxy.
+# If there are any entries specified, access is only granted for authenticated
+# users.
+#BasicAuth user password
+
 #
 # AddHeader: Adds the specified headers to outgoing HTTP requests that
 # Tinyproxy makes. Note that this option will not work for HTTPS

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -47,6 +47,7 @@ tinyproxy_SOURCES = \
 	utils.c utils.h \
 	vector.c vector.h \
 	upstream.c upstream.h \
+	basicauth.c basicauth.h \
 	connect-ports.c connect-ports.h
 
 EXTRA_tinyproxy_SOURCES = filter.c filter.h \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -48,6 +48,7 @@ tinyproxy_SOURCES = \
 	vector.c vector.h \
 	upstream.c upstream.h \
 	basicauth.c basicauth.h \
+	base64.c base64.h \
 	connect-ports.c connect-ports.h
 
 EXTRA_tinyproxy_SOURCES = filter.c filter.h \

--- a/src/base64.c
+++ b/src/base64.c
@@ -1,0 +1,57 @@
+/* tinyproxy - A fast light-weight HTTP proxy
+ * this file Copyright (C) 2016-2018 rofl0r
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "base64.h"
+
+static const char base64_tbl[64] =
+	"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+/*
+   rofl0r's base64 impl (taken from libulz)
+   takes count bytes from src, writing base64 encoded string into dst.
+   dst needs to be at least BASE64ENC_BYTES(count) + 1 bytes in size.
+   the string in dst will be zero-terminated.
+   */
+void base64enc(char *dst, const void* src, size_t count)
+{
+	unsigned const char *s = src;
+	char* d = dst;
+	while(count) {
+		int i = 0,  n = *s << 16;
+		s++;
+		count--;
+		if(count) {
+			n |= *s << 8;
+			s++;
+			count--;
+			i++;
+		}
+		if(count) {
+			n |= *s;
+			s++;
+			count--;
+			i++;
+		}
+		*d++ = base64_tbl[(n >> 18) & 0x3f];
+		*d++ = base64_tbl[(n >> 12) & 0x3f];
+		*d++ = i ? base64_tbl[(n >> 6) & 0x3f] : '=';
+		*d++ = i == 2 ? base64_tbl[n & 0x3f] : '=';
+	}
+	*d = 0;
+}
+

--- a/src/base64.h
+++ b/src/base64.h
@@ -1,0 +1,29 @@
+/* tinyproxy - A fast light-weight HTTP proxy
+ * this file Copyright (C) 2016-2018 rofl0r
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef TINYPROXY_BASE64_H
+#define TINYPROXY_BASE64_H
+
+#include <stddef.h>
+
+/* calculates number of bytes base64-encoded stream of N bytes will take. */
+#define BASE64ENC_BYTES(N) (((N+2)/3)*4)
+void base64enc(char *dst, const void* src, size_t count);
+
+#endif
+

--- a/src/basicauth.c
+++ b/src/basicauth.c
@@ -24,41 +24,7 @@
 #include "html-error.h"
 #include "log.h"
 #include "conf.h"
-
-/* calculates number of bytes base64-encoded stream of N bytes will take. */
-#define BASE64ENC_BYTES(N) (((N+2)/3)*4)
-
-static const char base64_tbl[64] =
-	"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-
-/* my own base64 impl (taken from libulz) */
-static void base64enc(char *dst, const void* src, size_t count)
-{
-	unsigned const char *s = src;
-	char* d = dst;
-	while(count) {
-		int i = 0,  n = *s << 16;
-		s++;
-		count--;
-		if(count) {
-			n |= *s << 8;
-			s++;
-			count--;
-			i++;
-		}
-		if(count) {
-			n |= *s;
-			s++;
-			count--;
-			i++;
-		}
-		*d++ = base64_tbl[(n >> 18) & 0x3f];
-		*d++ = base64_tbl[(n >> 12) & 0x3f];
-		*d++ = i ? base64_tbl[(n >> 6) & 0x3f] : '=';
-		*d++ = i == 2 ? base64_tbl[n & 0x3f] : '=';
-	}
-	*d = 0;
-}
+#include "base64.h"
 
 /*
  * Add entry to the basicauth list

--- a/src/basicauth.c
+++ b/src/basicauth.c
@@ -1,0 +1,122 @@
+/* tinyproxy - A fast light-weight HTTP proxy
+ * This file: Copyright (C) 2016-2017 rofl0r
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "main.h"
+#include "basicauth.h"
+
+#include "conns.h"
+#include "heap.h"
+#include "html-error.h"
+#include "log.h"
+#include "conf.h"
+
+/* calculates number of bytes base64-encoded stream of N bytes will take. */
+#define BASE64ENC_BYTES(N) (((N+2)/3)*4)
+
+static const char base64_tbl[64] =
+	"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+/* my own base64 impl (taken from libulz) */
+static void base64enc(char *dst, const void* src, size_t count)
+{
+	unsigned const char *s = src;
+	char* d = dst;
+	while(count) {
+		int i = 0,  n = *s << 16;
+		s++;
+		count--;
+		if(count) {
+			n |= *s << 8;
+			s++;
+			count--;
+			i++;
+		}
+		if(count) {
+			n |= *s;
+			s++;
+			count--;
+			i++;
+		}
+		*d++ = base64_tbl[(n >> 18) & 0x3f];
+		*d++ = base64_tbl[(n >> 12) & 0x3f];
+		*d++ = i ? base64_tbl[(n >> 6) & 0x3f] : '=';
+		*d++ = i == 2 ? base64_tbl[n & 0x3f] : '=';
+	}
+	*d = 0;
+}
+
+/*
+ * Add entry to the basicauth list
+ */
+void basicauth_add (vector_t authlist,
+	const char *user, const char *pass)
+{
+	char tmp[256+2];
+	char b[BASE64ENC_BYTES((sizeof tmp)-1) + 1];
+	int l;
+	size_t bl;
+
+        if (user == NULL || pass == NULL) {
+                log_message (LOG_WARNING,
+                             "Illegal basicauth rule: missing user or pass");
+                return;
+        }
+
+        l = snprintf(tmp, sizeof tmp, "%s:%s", user, pass);
+
+        if(l >= (ssize_t) sizeof tmp) {
+                log_message (LOG_WARNING,
+                            "User / pass in basicauth rule too long");
+                return;
+        }
+
+        base64enc(b, tmp, l);
+        bl = BASE64ENC_BYTES(l) + 1;
+
+        if (vector_append(authlist, b, bl) == -ENOMEM) {
+                log_message (LOG_ERR,
+                             "Unable to allocate memory in basicauth_add()");
+                return;
+        }
+
+        log_message (LOG_INFO,
+                     "Added basic auth user : %s", user);
+}
+
+/*
+ * Check if a user/password combination (encoded as base64)
+ * is in the basicauth list.
+ * return 1 on success, 0 on failure.
+ */
+int basicauth_check (vector_t authlist, const char *authstring)
+{
+        ssize_t vl, i;
+        size_t al, el;
+        const char* entry;
+
+        vl = vector_length (authlist);
+        if (vl == -EINVAL) return 0;
+
+        al = strlen (authstring);
+        for (i = 0; i < vl; i++) {
+                entry = vector_getentry (authlist, i, &el);
+                if (strncmp (authstring, entry, al) == 0)
+                        return 1;
+        }
+	return 0;
+}

--- a/src/basicauth.h
+++ b/src/basicauth.h
@@ -1,0 +1,31 @@
+/* tinyproxy - A fast light-weight HTTP proxy
+ * Copyright (C) 2005 Robert James Kaes <rjkaes@users.sourceforge.net>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+/* See 'basicauth.c' for detailed information. */
+
+#ifndef TINYPROXY_BASICAUTH_H
+#define TINYPROXY_BASICAUTH_H
+
+#include "vector.h"
+
+extern void basicauth_add (vector_t authlist,
+	const char *user, const char *pass);
+
+extern int basicauth_check (vector_t authlist, const char *authstring);
+
+#endif

--- a/src/conf.h
+++ b/src/conf.h
@@ -37,6 +37,7 @@ typedef struct {
  * Hold all the configuration time information.
  */
 struct config_s {
+        vector_t basicauth_list;
         char *logf_name;
         char *config_file;
         unsigned int syslog;    /* boolean */

--- a/src/html-error.c
+++ b/src/html-error.c
@@ -156,13 +156,24 @@ send_html_file (FILE *infile, struct conn_s *connptr)
 
 int send_http_headers (struct conn_s *connptr, int code, const char *message)
 {
-        const char *headers =
+        const char headers[] =
             "HTTP/1.0 %d %s\r\n"
             "Server: %s/%s\r\n"
-            "Content-Type: text/html\r\n" "Connection: close\r\n" "\r\n";
+            "Content-Type: text/html\r\n"
+            "%s"
+            "Connection: close\r\n" "\r\n";
+
+        const char auth_str[] =
+            "Proxy-Authenticate: Basic realm=\""
+            PACKAGE_NAME "\"\r\n";
+
+	/* according to rfc7235, the 407 error must be accompanied by
+           a Proxy-Authenticate header field. */
+        const char *add = code == 407 ? auth_str : "";
 
         return (write_message (connptr->client_fd, headers,
-                               code, message, PACKAGE, VERSION));
+                               code, message, PACKAGE, VERSION,
+                               add));
 }
 
 /*

--- a/src/reqs.c
+++ b/src/reqs.c
@@ -1563,29 +1563,37 @@ void handle_connection (int fd)
                 goto fail;
         }
 
-	if (config.basicauth_list != NULL) {
-		ssize_t len;
-		char *authstring;
-		int failure = 1;
-		len = hashmap_entry_by_key (hashofheaders, "proxy-authorization",
-                                  (void **) &authstring);
-		if (len > 0 &&
-		/* currently only "basic" auth supported */
-			(strncmp(authstring, "Basic ", 6) == 0 ||
-			 strncmp(authstring, "basic ", 6) == 0) &&
-			basicauth_check (config.basicauth_list, authstring + 6) == 1)
-				failure = 0;
-		if(failure) {
-			update_stats (STAT_DENIED);
-			indicate_http_error (connptr, 403, "Access denied",
-					     "detail",
-					     "The administrator of this proxy has not configured "
-					     "it to service requests from you.",
-					     NULL);
-			goto fail;
-		}
-		hashmap_remove (hashofheaders, "proxy-authorization");
-	}
+        if (config.basicauth_list != NULL) {
+                ssize_t len;
+                char *authstring;
+                int failure = 1;
+                len = hashmap_entry_by_key (hashofheaders, "proxy-authorization",
+                                            (void **) &authstring);
+
+                if (len == 0) {
+                        update_stats (STAT_DENIED);
+                        indicate_http_error (connptr, 407, "Proxy Authentication Required",
+                                             "detail",
+                                             "This proxy requires authentication.",
+                                             NULL);
+                        goto fail;
+                }
+                if ( /* currently only "basic" auth supported */
+                        (strncmp(authstring, "Basic ", 6) == 0 ||
+                         strncmp(authstring, "basic ", 6) == 0) &&
+                        basicauth_check (config.basicauth_list, authstring + 6) == 1)
+                                failure = 0;
+                if(failure) {
+                        update_stats (STAT_DENIED);
+                        indicate_http_error (connptr, 401, "Unauthorized",
+                                             "detail",
+                                             "The administrator of this proxy has not configured "
+                                             "it to service requests from you.",
+                                             NULL);
+                        goto fail;
+                }
+                hashmap_remove (hashofheaders, "proxy-authorization");
+        }
 
         /*
          * Add any user-specified headers (AddHeader directive) to the


### PR DESCRIPTION
using the "BasicAuth" keyword in tinyproxy.conf.

base64 code was written by myself and taken from my own library "libulz".
for this purpose it is relicensed under the usual terms of the tinyproxy
license.