### PR TITLE
Remove #ifdef for syslog.h

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -783,12 +783,7 @@ static HANDLE_FUNC (handle_xtinyproxy)
 
 static HANDLE_FUNC (handle_syslog)
 {
-#ifdef HAVE_SYSLOG_H
         return set_bool_arg (&conf->syslog, line, &match[2]);
-#else
-        fprintf (stderr, "Syslog support not compiled in executable.\n");
-        return 1;
-#endif
 }
 
 static HANDLE_FUNC (handle_bindsame)


### PR DESCRIPTION
The configure.ac file was missing a check for syslog.h, preventing the syslog feature from being enabled.