### PR TITLE
add support for upstream with basic http auth

### DIFF
--- a/etc/tinyproxy.conf.in
+++ b/etc/tinyproxy.conf.in
@@ -146,6 +146,9 @@ LogLevel Info
 #  upstream testproxy:8008 ".our_testbed.example.com"
 #  upstream testproxy:8008 "192.168.128.0/255.255.254.0"
 #
+#  # upstream proxy using basic authentication
+#  upstream user:pass@testproxy:8008 ".test.domain.invalid"
+#
 #  # no upstream proxy for internal websites and unqualified hosts
 #  no upstream ".internal.example.com"
 #  no upstream "www.example.com"

--- a/src/basicauth.c
+++ b/src/basicauth.c
@@ -27,34 +27,45 @@
 #include "base64.h"
 
 /*
+ * Create basic-auth token in buf.
+ * Returns strlen of token on success,
+ * -1 if user/pass missing
+ * 0 if user/pass too long
+ */
+ssize_t basicauth_string(const char *user, const char *pass,
+	char *buf, size_t bufsize)
+{
+	char tmp[256+2];
+	int l;
+	if (!user || !pass) return -1;
+	l = snprintf(tmp, sizeof tmp, "%s:%s", user, pass);
+	if (l < 0 || l >= (ssize_t) sizeof tmp) return 0;
+	if (bufsize < (BASE64ENC_BYTES((unsigned)l) + 1)) return 0;
+	base64enc(buf, tmp, l);
+	return BASE64ENC_BYTES(l);
+}
+
+/*
  * Add entry to the basicauth list
  */
 void basicauth_add (vector_t authlist,
 	const char *user, const char *pass)
 {
-	char tmp[256+2];
-	char b[BASE64ENC_BYTES((sizeof tmp)-1) + 1];
-	int l;
-	size_t bl;
+	char b[BASE64ENC_BYTES((256+2)-1) + 1];
+	ssize_t ret;
 
-        if (user == NULL || pass == NULL) {
+        ret = basicauth_string(user, pass, b, sizeof b);
+        if (ret == -1) {
                 log_message (LOG_WARNING,
                              "Illegal basicauth rule: missing user or pass");
                 return;
-        }
-
-        l = snprintf(tmp, sizeof tmp, "%s:%s", user, pass);
-
-        if(l >= (ssize_t) sizeof tmp) {
+        } else if (ret == 0) {
                 log_message (LOG_WARNING,
-                            "User / pass in basicauth rule too long");
+                             "User / pass in basicauth rule too long");
                 return;
         }
 
-        base64enc(b, tmp, l);
-        bl = BASE64ENC_BYTES(l) + 1;
-
-        if (vector_append(authlist, b, bl) == -ENOMEM) {
+        if (vector_append(authlist, b, ret + 1) == -ENOMEM) {
                 log_message (LOG_ERR,
                              "Unable to allocate memory in basicauth_add()");
                 return;

--- a/src/basicauth.h
+++ b/src/basicauth.h
@@ -21,7 +21,11 @@
 #ifndef TINYPROXY_BASICAUTH_H
 #define TINYPROXY_BASICAUTH_H
 
+#include <stddef.h>
 #include "vector.h"
+
+extern ssize_t basicauth_string(const char *user, const char *pass,
+	char *buf, size_t bufsize);
 
 extern void basicauth_add (vector_t authlist,
 	const char *user, const char *pass);

--- a/src/reqs.c
+++ b/src/reqs.c
@@ -270,6 +270,17 @@ establish_http_connection (struct conn_s *connptr, struct request_s *request)
                                       "Connection: close\r\n",
                                       request->method, request->path,
                                       request->host, portbuff);
+        } else if (connptr->upstream_proxy &&
+                   connptr->upstream_proxy->type == HTTP_TYPE &&
+                   connptr->upstream_proxy->ua.authstr) {
+                return write_message (connptr->server_fd,
+                                      "%s %s HTTP/1.0\r\n"
+                                      "Host: %s%s\r\n"
+                                      "Connection: close\r\n"
+                                      "Proxy-Authorization: Basic %s\r\n",
+                                      request->method, request->path,
+                                      request->host, portbuff,
+                                      connptr->upstream_proxy->ua.authstr);
         } else {
                 return write_message (connptr->server_fd,
                                       "%s %s HTTP/1.0\r\n"

--- a/src/upstream.h
+++ b/src/upstream.h
@@ -36,6 +36,11 @@ struct upstream {
         struct upstream *next;
         char *domain;           /* optional */
         char *host;
+        union {
+                char *user;
+                char *authstr;
+        } ua;
+        char *pass;
         int port;
         in_addr_t ip, mask;
         proxy_type type;
@@ -44,6 +49,7 @@ struct upstream {
 #ifdef UPSTREAM_SUPPORT
 const char *proxy_type_name(proxy_type type);
 extern void upstream_add (const char *host, int port, const char *domain,
+                          const char *user, const char *pass,
                           proxy_type type, struct upstream **upstream_list);
 extern struct upstream *upstream_get (char *host, struct upstream *up);
 extern void free_upstream_list (struct upstream *up);


### PR DESCRIPTION
superseding #38 and #96

after merge, i will refactor the upstream directive to look like
```
# upstream proxy_type user:pass@proxy:port "domain"
# e.g.
upstream http foo:bar@localhost:9999 "invalid.domain"
upstream socks5 freeproxy.com:1080
upstream socks4 localhost:9050
```
and add upstream authentication for socks too.

right now, the upstream4 and upstream5 directives look quite ugly, imo.

@gbasto and @valenbg1 : please test