### PR TITLE
Unified upstream

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -173,7 +173,7 @@ AC_CHECK_FUNCS([inet_ntoa strdup])
 AC_CHECK_FUNCS([strlcpy strlcat setgroups])
 
 dnl Enable extra warnings
-DESIRED_FLAGS="-fdiagnostics-show-option -Wall -Wextra -Wno-unused-parameter -Wmissing-prototypes -Wstrict-prototypes -Wmissing-declarations -Wfloat-equal -Wundef -Wformat=2 -Wlogical-op -Wmissing-include-dirs -Wformat-nonliteral -Wold-style-definition -Wpointer-arith -Waggregate-return -Winit-self -Wpacked --std=c89 -ansi -pedantic -Wno-overlength-strings -Wno-long-long -Wno-overlength-strings -Wdeclaration-after-statement -Wredundant-decls -Wmissing-noreturn -Wshadow -Wendif-labels -Wcast-qual -Wcast-align -Wwrite-strings -Wp,-D_FORTIFY_SOURCE=2 -fno-common"
+DESIRED_FLAGS="-fdiagnostics-show-option -Wall -Wextra -Wno-unused-parameter -Wmissing-prototypes -Wstrict-prototypes -Wmissing-declarations -Wfloat-equal -Wundef -Wformat=2 -Wlogical-op -Wmissing-include-dirs -Wformat-nonliteral -Wold-style-definition -Wpointer-arith -Waggregate-return -Winit-self -Wpacked --std=c89 -ansi -Wno-overlength-strings -Wno-long-long -Wno-overlength-strings -Wdeclaration-after-statement -Wredundant-decls -Wmissing-noreturn -Wshadow -Wendif-labels -Wcast-qual -Wcast-align -Wwrite-strings -Wp,-D_FORTIFY_SOURCE=2 -fno-common"
 
 if test -n "${MAINTAINER_MODE_FALSE}"; then
    DESIRED_FLAGS="-Werror $DESIRED_FLAGS"

--- a/docs/man5/tinyproxy.conf.txt.in
+++ b/docs/man5/tinyproxy.conf.txt.in
@@ -144,21 +144,25 @@ The possible keywords and their descriptions are as follows:
     `X-Tinyproxy` containing the client's IP address to the request.
 
 *Upstream*::
-*No Upstream*::
 
     This option allows you to set up a set of rules for deciding
     whether an upstream proxy server is to be used, based on the
     host or domain of the site being accessed. The rules are stored
     in the order encountered in the configuration file and the
-    LAST matching rule wins. There are three possible forms for
-    specifying upstream rules:
+    LAST matching rule wins. The following forms for specifying upstream
+    rules exist:
 
-    * 'upstream host:port' turns proxy upstream support on generally.
+    * 'upstream type host:port' turns proxy upstream support on generally.
 
-    * 'upstream host:port "site_spec"' turns on the upstream proxy for
-    the sites matching `site_spec`.
+    * 'upstream type user:pass@host:port' does the same, but uses the
+    supplied credentials for authentication.
 
-    * 'no upstream "site_spec"' turns off upstream support for sites
+    * 'upstream type host:port "site_spec"' turns on the upstream proxy
+    for the sites matching `site_spec`.
+
+    `type` can be one of `http`, `socks4`, `socks5`, `none`.
+
+    * 'upstream none "site_spec"' turns off upstream support for sites
     matching `site_spec`.
 
     The site can be specified in various forms as a hostname, domain

--- a/etc/tinyproxy.conf.in
+++ b/etc/tinyproxy.conf.in
@@ -140,32 +140,37 @@ LogLevel Info
 # The upstream rules allow you to selectively route upstream connections
 # based on the host/domain of the site being accessed.
 #
+# Syntax: upstream type (user:pass@)ip:port ("domain")
+# Or:     upstream none "domain"
+# The parts in parens are optional.
+# Possible types are http, socks4, socks5, none
+#
 # For example:
 #  # connection to test domain goes through testproxy
-#  upstream testproxy:8008 ".test.domain.invalid"
-#  upstream testproxy:8008 ".our_testbed.example.com"
-#  upstream testproxy:8008 "192.168.128.0/255.255.254.0"
+#  upstream http testproxy:8008 ".test.domain.invalid"
+#  upstream http testproxy:8008 ".our_testbed.example.com"
+#  upstream http testproxy:8008 "192.168.128.0/255.255.254.0"
 #
 #  # upstream proxy using basic authentication
-#  upstream user:pass@testproxy:8008 ".test.domain.invalid"
+#  upstream http user:pass@testproxy:8008 ".test.domain.invalid"
 #
 #  # no upstream proxy for internal websites and unqualified hosts
-#  no upstream ".internal.example.com"
-#  no upstream "www.example.com"
-#  no upstream "10.0.0.0/8"
-#  no upstream "192.168.0.0/255.255.254.0"
-#  no upstream "."
+#  upstream none ".internal.example.com"
+#  upstream none "www.example.com"
+#  upstream none "10.0.0.0/8"
+#  upstream none "192.168.0.0/255.255.254.0"
+#  upstream none "."
 #
 #  # connection to these boxes go through their DMZ firewalls
-#  upstream cust1_firewall:8008 "testbed_for_cust1"
-#  upstream cust2_firewall:8008 "testbed_for_cust2"
+#  upstream http cust1_firewall:8008 "testbed_for_cust1"
+#  upstream http cust2_firewall:8008 "testbed_for_cust2"
 #
 #  # default upstream is internet firewall
-#  upstream firewall.internal.example.com:80
+#  upstream http firewall.internal.example.com:80
 #
-# You may also use SOCKS4/SOCKS5 upstream proxies by using upstream4/upstream5:
-#  upstream4 127.0.0.1:9050
-#  upstream5 socksproxy:1080
+# You may also use SOCKS4/SOCKS5 upstream proxies:
+#  upstream socks4 127.0.0.1:9050
+#  upstream socks5 socksproxy:1080
 #
 # The LAST matching rule wins the route decision.  As you can see, you
 # can use a host, or a domain:
@@ -175,7 +180,7 @@ LogLevel Info
 #  IP/bits  matches network/mask
 #  IP/mask  matches network/mask
 #
-#Upstream some.remote.proxy:port
+#Upstream http some.remote.proxy:port
 
 #
 # MaxClients: This is the absolute highest number of threads which will

--- a/src/conf.c
+++ b/src/conf.c
@@ -1137,17 +1137,17 @@ static int _handle_upstream(struct config_s* conf, const char* line,
 
 static HANDLE_FUNC (handle_upstream)
 {
-	return _handle_upstream(conf, line, match, HTTP_TYPE);
+	return _handle_upstream(conf, line, match, PT_HTTP);
 }
 
 static HANDLE_FUNC (handle_upstream4)
 {
-	return _handle_upstream(conf, line, match, SOCKS4_TYPE);
+	return _handle_upstream(conf, line, match, PT_SOCKS4);
 }
 
 static HANDLE_FUNC (handle_upstream5)
 {
-	return _handle_upstream(conf, line, match, SOCKS5_TYPE);
+	return _handle_upstream(conf, line, match, PT_SOCKS5);
 }
 
 static HANDLE_FUNC (handle_upstream_no)
@@ -1158,7 +1158,7 @@ static HANDLE_FUNC (handle_upstream_no)
         if (!domain)
                 return -1;
 
-        upstream_add (NULL, 0, domain, 0, 0, HTTP_TYPE, &conf->upstream_list);
+        upstream_add (NULL, 0, domain, 0, 0, PT_HTTP, &conf->upstream_list);
         safefree (domain);
 
         return 0;

--- a/src/reqs.c
+++ b/src/reqs.c
@@ -62,7 +62,7 @@
 #ifdef UPSTREAM_SUPPORT
 #  define UPSTREAM_CONFIGURED() (config.upstream_list != NULL)
 #  define UPSTREAM_HOST(host) upstream_get(host, config.upstream_list)
-#  define UPSTREAM_IS_HTTP(conn) (conn->upstream_proxy != NULL && conn->upstream_proxy->type == HTTP_TYPE)
+#  define UPSTREAM_IS_HTTP(conn) (conn->upstream_proxy != NULL && conn->upstream_proxy->type == PT_HTTP)
 #else
 #  define UPSTREAM_CONFIGURED() (0)
 #  define UPSTREAM_HOST(host) (NULL)
@@ -271,7 +271,7 @@ establish_http_connection (struct conn_s *connptr, struct request_s *request)
                                       request->method, request->path,
                                       request->host, portbuff);
         } else if (connptr->upstream_proxy &&
-                   connptr->upstream_proxy->type == HTTP_TYPE &&
+                   connptr->upstream_proxy->type == PT_HTTP &&
                    connptr->upstream_proxy->ua.authstr) {
                 return write_message (connptr->server_fd,
                                       "%s %s HTTP/1.0\r\n"
@@ -1292,7 +1292,7 @@ connect_to_upstream_proxy(struct conn_s *connptr, struct request_s *request)
 		    "Established connection to %s proxy \"%s\" using file descriptor %d.",
 		    proxy_type_name(cur_upstream->type), cur_upstream->host, connptr->server_fd);
 
-	if (cur_upstream->type == SOCKS4_TYPE) {
+	if (cur_upstream->type == PT_SOCKS4) {
 
 		buff[0] = 4; /* socks version */
 		buff[1] = 1; /* connect command */
@@ -1308,7 +1308,7 @@ connect_to_upstream_proxy(struct conn_s *connptr, struct request_s *request)
 		if (buff[0]!=0 || buff[1]!=90)
 			return -1;
 
-	} else if (cur_upstream->type == SOCKS5_TYPE) {
+	} else if (cur_upstream->type == PT_SOCKS5) {
 
 		/* init */
 		buff[0] = 5; /* socks version */
@@ -1404,7 +1404,7 @@ connect_to_upstream (struct conn_s *connptr, struct request_s *request)
                 return -1;
         }
 
-	if (cur_upstream->type != HTTP_TYPE)
+	if (cur_upstream->type != PT_HTTP)
 		return connect_to_upstream_proxy(connptr, request);
 
         log_message (LOG_CONN,

--- a/src/upstream.c
+++ b/src/upstream.c
@@ -35,9 +35,10 @@ const char *
 proxy_type_name(proxy_type type)
 {
     switch(type) {
-        case HTTP_TYPE: return "http";
-        case SOCKS4_TYPE: return "socks4";
-        case SOCKS5_TYPE: return "socks5";
+        case PT_NONE: return "none";
+        case PT_HTTP: return "http";
+        case PT_SOCKS4: return "socks4";
+        case PT_SOCKS5: return "socks5";
         default: return "unknown";
     }
 }
@@ -63,7 +64,7 @@ static struct upstream *upstream_build (const char *host, int port, const char *
         up->host = up->domain = up->ua.user = up->pass = NULL;
         up->ip = up->mask = 0;
         if (user) {
-                if (type == HTTP_TYPE) {
+                if (type == PT_HTTP) {
                         char b[BASE64ENC_BYTES((256+2)-1) + 1];
                         ssize_t ret;
                         ret = basicauth_string(user, pass, b, sizeof b);

--- a/src/upstream.c
+++ b/src/upstream.c
@@ -92,7 +92,7 @@ static struct upstream *upstream_build (const char *host, int port, const char *
 
                 log_message (LOG_INFO, "Added upstream %s %s:%d for [default]",
                              proxy_type_name(type), host, port);
-        } else if (host == NULL) {
+        } else if (host == NULL || type == PT_NONE) {
                 if (!domain || domain[0] == '\0') {
                         log_message (LOG_WARNING,
                                      "Nonsense no-upstream rule: empty domain");

--- a/src/upstream.h
+++ b/src/upstream.h
@@ -31,7 +31,13 @@
  * Even if upstream support is not compiled into tinyproxy, this
  * structure still needs to be defined.
  */
-typedef enum {HTTP_TYPE, SOCKS4_TYPE, SOCKS5_TYPE} proxy_type;
+typedef enum proxy_type {
+	PT_NONE = 0,
+	PT_HTTP,
+	PT_SOCKS4,
+	PT_SOCKS5
+} proxy_type;
+
 struct upstream {
         struct upstream *next;
         char *domain;           /* optional */


### PR DESCRIPTION
merges upstream syntax together:

before:
```
upstream httpproxy:8080 "domain"
upstream otherproxy:8080
upstream user:pass@httpproxy:8080 "domain"
upstream4 socks4proxy:9050 "domain"
upstream5 socks5proxy:1080 "domain"
no upstream "otherdomain"
```

after:
```
upstream http httpproxy:8080 "domain"
upstream http otherproxy:8080
upstream http user:pass@httpproxy:8080 "domain"
upstream socks4 socks4proxy:9050 "domain"
upstream socks5 socks5proxy:1080 "domain"
upstream none "otherdomain"
```
