### PR TITLE
enable transparent proxy by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -124,8 +124,8 @@ dnl Include the transparent proxy support
 AH_TEMPLATE([TRANSPARENT_PROXY],
 	    [Include support for using tinyproxy as a transparent proxy.])
 TP_ARG_ENABLE(transparent,
-              [Enable transparent proxying code (default is NO)],
-              no)
+              [Enable transparent proxying code (default is YES)],
+              yes)
 if test x"$transparent_enabled" = x"yes"; then
    ADDITIONAL_OBJECTS="$ADDITIONAL_OBJECTS transparent-proxy.o"
    AC_DEFINE(TRANSPARENT_PROXY)


### PR DESCRIPTION
by having all features turned on by default, the binary is only
slightly bigger, but users of binary distros get the whole package
and don't need to compile tinyproxy by hand if they need a feature
that wasn't compiled in.
it also prevents the confusion from getting syntax errors when a
config file using those features is parsed.
another advantage is that by enabling them these features may
actually get some more testing.