### PR TITLE
do not daemonize by default, change -d switch to -D

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -147,7 +147,7 @@ display_usage (void)
         printf ("Usage: %s [options]\n", PACKAGE);
         printf ("\n"
                 "Options are:\n"
-                "  -d        Do not daemonize (run in foreground).\n"
+                "  -D        Daemonize (fork into background).\n"
                 "  -c FILE   Use an alternate configuration file.\n"
                 "  -h        Display this usage information.\n"
                 "  -l        Display the license.\n"
@@ -224,7 +224,7 @@ process_cmdline (int argc, char **argv, struct config_s *conf)
 {
         int opt;
 
-        while ((opt = getopt (argc, argv, "c:vldh")) != EOF) {
+        while ((opt = getopt (argc, argv, "c:vlDh")) != EOF) {
                 switch (opt) {
                 case 'v':
                         display_version ();
@@ -234,8 +234,8 @@ process_cmdline (int argc, char **argv, struct config_s *conf)
                         display_license ();
                         exit (EX_OK);
 
-                case 'd':
-                        conf->godaemon = FALSE;
+                case 'D':
+                        conf->godaemon = TRUE;
                         break;
 
                 case 'c':
@@ -347,7 +347,7 @@ static void initialize_config_defaults (struct config_s *conf)
                 fprintf (stderr, PACKAGE ": Could not allocate memory.\n");
                 exit (EX_SOFTWARE);
         }
-        conf->godaemon = TRUE;
+        conf->godaemon = FALSE;
         /*
          * Make sure the HTML error pages array is NULL to begin with.
          * (FIXME: Should have a better API for all this)

--- a/tests/scripts/run_tests.sh
+++ b/tests/scripts/run_tests.sh
@@ -103,7 +103,7 @@ EOF
 
 start_tinyproxy() {
 	echo -n "starting tinyproxy..."
-	$VALGRIND $TINYPROXY_BIN -c $TINYPROXY_CONF_FILE 2> $TINYPROXY_STDERR_LOG
+	$VALGRIND $TINYPROXY_BIN -D -c $TINYPROXY_CONF_FILE 2> $TINYPROXY_STDERR_LOG
 	echo " done (listening on $TINYPROXY_IP:$TINYPROXY_PORT)"
 }
 


### PR DESCRIPTION
having the program forking into background by default is a very
unintuitive behaviour (imagine a new user running just `tinyproxy` without arguments, expecting to see help output), and in case an error happens the process
terminates "silently" with no traces on stdout (that is, it will only log the error to logfile).
from the PoV of a new user, it looks as if the program just terminates without any output, even when successful.

rather than reversing the meaning of the -d command line option, we
replace it with -D so users will notice the change and can change their
scripts, instead of getting a silently different behaviour.

i'm aware that this change is controversial and users will have to change their service scripts.

OTOH, it's been two years since the latest release so we can go directly to 2.0-rc1 and bring some fresh air. there have been other sensible changes that may require some attention from package maintainers anyhow.

anyway, i'm not gonna merge this right away, feel free to leave your opinion (hopefully accompanied by reasonable arguments).