### PR TITLE
make bind option usable with transparent proxy too

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -876,7 +876,6 @@ static HANDLE_FUNC (handle_deny)
 
 static HANDLE_FUNC (handle_bind)
 {
-#ifndef TRANSPARENT_PROXY
         int r = set_string_arg (&conf->bind_address, line, &match[2]);
 
         if (r)
@@ -884,7 +883,6 @@ static HANDLE_FUNC (handle_bind)
         log_message (LOG_INFO,
                      "Outgoing connections bound to IP %s", conf->bind_address);
         return 0;
-#endif
 }
 
 static HANDLE_FUNC (handle_listen)


### PR DESCRIPTION
closes #15 for real.
the previous patch that was merged[0] was halfbaked and only removed
the warning part of the original patch from openwrt[1], but didn't
actually activate bind support. further it invoked UB by removing
the return value from the function, if transparent proxy support was
compiled in.

[0]: d97d486d53ce214ae952378308292f333b8c7a36
[1]: https://gitlab.labs.nic.cz/turris/openwrt-packages/commit/7c01da4a72e6f0b7613a86529547659ea4007eba