### PR TITLE
upstream: Fix case of empty string domain.

### DIFF
--- a/src/upstream.c
+++ b/src/upstream.c
@@ -124,7 +124,7 @@ static struct upstream *upstream_build (const char *host, int port, const char *
                 log_message (LOG_INFO, "Added no-upstream for %s", domain);
         } else {
                 if (!host || host[0] == '\0' || port < 1 || !domain
-                    || domain == '\0') {
+                    || domain[0] == '\0') {
                         log_message (LOG_WARNING,
                                      "Nonsense upstream rule: invalid parameters");
                         goto fail;


### PR DESCRIPTION
Found by compiler note.

Signed-off-by: Michael Adam <obnox@samba.org>