### PR TITLE
install tinyproxy to bin/, not /sbin

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -17,7 +17,7 @@
 
 pkgsysconfdir = $(sysconfdir)/$(PACKAGE)
 
-sbin_PROGRAMS = tinyproxy
+bin_PROGRAMS = tinyproxy
 
 AM_CPPFLAGS = \
 	-DSYSCONFDIR=\"${pkgsysconfdir}\" \


### PR DESCRIPTION
sbin/ is meant for programs only usable by root, but in tinyproxy's
case, regular users can and *should* use tinyproxy; meaning it is
preferable from a security PoV to use tinyproxy as regular user.