### PR TITLE
html-error: Make a switch fallthrough explicit

### DIFF
--- a/src/html-error.c
+++ b/src/html-error.c
@@ -132,6 +132,7 @@ send_html_file (FILE *infile, struct conn_s *connptr)
                                 } else
                                         in_variable = 0;
 
+                                /* FALL THROUGH */
                         default:
                                 if (!in_variable) {
                                         r = write_message (connptr->client_fd,


### PR DESCRIPTION
This silences a gcc v7 compile warning.

Signed-off-by: Michael Adam <obnox@samba.org>