### PR TITLE
Fix upstream for network

### DIFF
--- a/src/upstream.c
+++ b/src/upstream.c
@@ -46,7 +46,7 @@ proxy_type_name(proxy_type type)
 /**
  * Parse and process a netmask format (IP/mask), otherwise treat as a domain
  */
-static void upstream_handle_site_spec(struct upstream *up, const char *domain)
+static int upstream_handle_site_spec(struct upstream *up, const char *domain)
 {
         char *ptr;
 
@@ -63,14 +63,18 @@ static void upstream_handle_site_spec(struct upstream *up, const char *domain)
                                 if (inet_aton (ptr, &addrstruct) != 0)
                                         up->mask =
                                             ntohl (addrstruct.s_addr);
+                                else return 0;
                         } else {
                                 up->mask =
                                     ~((1 << (32 - atoi (ptr))) - 1);
                         }
+                } else {
+                    return 0;
                 }
         } else {
                 up->domain = safestrdup (domain);
         }
+        return 1;
 }
 /**
  * Construct an upstream struct from input data.
@@ -127,7 +131,11 @@ static struct upstream *upstream_build (const char *host, int port, const char *
                         goto fail;
                 }
 
-                upstream_handle_site_spec(up, domain);
+                if (!upstream_handle_site_spec(up, domain)) {
+                        log_message (LOG_WARNING,
+                                     "Nonsense no-upstream rule: malformed IP address or mask");
+                        goto fail;
+                }
 
                 log_message (LOG_INFO, "Added no-upstream for %s", domain);
         } else {
@@ -141,7 +149,11 @@ static struct upstream *upstream_build (const char *host, int port, const char *
                 up->host = safestrdup (host);
                 up->port = port;
 
-                upstream_handle_site_spec(up, domain);
+                if (!upstream_handle_site_spec(up, domain)) {
+                        log_message (LOG_WARNING,
+                                     "Nonsense upstream rule: malformed IP address or mask");
+                        goto fail;
+                }
 
                 log_message (LOG_INFO, "Added upstream %s %s:%d for %s",
                              proxy_type_name(type), host, port, domain);

--- a/src/upstream.c
+++ b/src/upstream.c
@@ -140,7 +140,8 @@ static struct upstream *upstream_build (const char *host, int port, const char *
 
                 up->host = safestrdup (host);
                 up->port = port;
-                up->domain = safestrdup (domain);
+
+                upstream_handle_site_spec(up, domain);
 
                 log_message (LOG_INFO, "Added upstream %s %s:%d for %s",
                              proxy_type_name(type), host, port, domain);


### PR DESCRIPTION
Follow PR #163 's comments, split into commits, and try to describe the bug was.

The bug was so simple.
There were no "IP/mask" handler for normal (ie; not "none" type of) upstream directive.
The "IP/mask" was treated as a domain name, thus it never matched to a network you want.

closes #83 
