### PR TITLE
fix socks5 upstream user/pass subnegotiation check

### DIFF
--- a/src/reqs.c
+++ b/src/reqs.c
@@ -1350,7 +1350,7 @@ connect_to_upstream_proxy(struct conn_s *connptr, struct request_s *request)
 
 			if(2 != safe_read(connptr->server_fd, in, 2))
 				return -1;
-			if(in[0] != 5 || in[1] != 0) {
+			if(in[1] != 0 || !(in[0] == 5 || in[0] == 1)) {
 				return -1;
 			}
 		}


### PR DESCRIPTION
RFC 1929 specifies that the user/pass auth subnegotation repurposes the version
field for the version of that specification, which is 1, not 5.
however there's quite a good deal of software out there which got it wrong and
replies with version 5 to a successful authentication, so let's just accept both
forms - other socks5 client programs like curl do the same.

closes #172

this seems to be a common issue... i fixed the same bug today in proxychains-ng and microsocks.

https://github.com/rofl0r/proxychains-ng/commit/49d8ac933894a3eddaea387cfc62d70661fb7cf4

https://github.com/rofl0r/microsocks/commit/1998a16a23a6a15fff7de91220b698efb9040ee8