### PR TITLE
Added way more liberty on password value

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -52,6 +52,7 @@
 #define BOOL "(yes|on|no|off)"
 #define INT "((0x)?[[:digit:]]+)"
 #define ALNUM "([-a-z0-9._]+)"
+#define PASSWORD "([^:@]+)"
 #define IP "((([0-9]{1,3})\\.){3}[0-9]{1,3})"
 #define IPMASK "(" IP "(/[[:digit:]]+)?)"
 #define IPV6 "(" \
@@ -257,7 +258,7 @@ struct {
         },
         {
                 BEGIN "(upstream)" WS "(http|socks4|socks5)" WS
-                      "(" ALNUM /*username*/ ":" ALNUM /*password*/ "@" ")?"
+                      "(" ALNUM /*username*/ ":" PASSWORD /*password*/ "@" ")?"
                       "(" IP "|" ALNUM ")"
                       ":" INT "(" WS STR ")?"
                 END, handle_upstream, NULL

--- a/src/conf.c
+++ b/src/conf.c
@@ -52,7 +52,8 @@
 #define BOOL "(yes|on|no|off)"
 #define INT "((0x)?[[:digit:]]+)"
 #define ALNUM "([-a-z0-9._]+)"
-#define PASSWORD "([^:@]*)"
+#define USERNAME "([^:]*)"
+#define PASSWORD "([^@]*)"
 #define IP "((([0-9]{1,3})\\.){3}[0-9]{1,3})"
 #define IPMASK "(" IP "(/[[:digit:]]+)?)"
 #define IPV6 "(" \
@@ -258,7 +259,7 @@ struct {
         },
         {
                 BEGIN "(upstream)" WS "(http|socks4|socks5)" WS
-                      "(" ALNUM /*username*/ ":" PASSWORD /*password*/ "@" ")?"
+                      "(" USERNAME /*username*/ ":" PASSWORD /*password*/ "@" ")?"
                       "(" IP "|" ALNUM ")"
                       ":" INT "(" WS STR ")?"
                 END, handle_upstream, NULL

--- a/src/conf.c
+++ b/src/conf.c
@@ -52,7 +52,7 @@
 #define BOOL "(yes|on|no|off)"
 #define INT "((0x)?[[:digit:]]+)"
 #define ALNUM "([-a-z0-9._]+)"
-#define PASSWORD "([^:@]+)"
+#define PASSWORD "([^:@]*)"
 #define IP "((([0-9]{1,3})\\.){3}[0-9]{1,3})"
 #define IPMASK "(" IP "(/[[:digit:]]+)?)"
 #define IPV6 "(" \


### PR DESCRIPTION
Restricting password to be alphanumeric is strange at the very least... This change proposes to lift this limitation and only ban ":" and "@" (so we can distinguish username on the left and host on the right).

This works on my local machine just fine.