### PR TITLE
WIP: Allow http upgrades w/o using connect method.

### DIFF
--- a/etc/tinyproxy.conf.in
+++ b/etc/tinyproxy.conf.in
@@ -236,6 +236,14 @@ Allow 127.0.0.1
 #AddHeader "X-My-Header" "Powered by Tinyproxy"
 
 #
+# AllowUpgrade: 'Upgrade' and 'Connection' headers are stripped in
+# non-HTTPS connections per proxy operation in the HTTP RFC. Enabling
+# fixes unencrypted WebSocket connections but is RFC 2616 non-compliant.
+# May cause issues with in-connection upgrades to unencrypted HTTP/2.
+# Don't enable unless you know what you are doing.
+# AllowUpgrade Yes
+
+#
 # ViaProxyName: The "Via" header is required by the HTTP RFC, but using
 # the real host name is a security concern.  If the following directive
 # is enabled, the string supplied will be used as the host name in the

--- a/src/conf.c
+++ b/src/conf.c
@@ -126,6 +126,7 @@ static HANDLE_FUNC (handle_defaulterrorfile);
 static HANDLE_FUNC (handle_deny);
 static HANDLE_FUNC (handle_errorfile);
 static HANDLE_FUNC (handle_addheader);
+static HANDLE_FUNC (handle_allowupgrade);
 #ifdef FILTER_ENABLE
 static HANDLE_FUNC (handle_filter);
 static HANDLE_FUNC (handle_filtercasesensitive);
@@ -235,6 +236,7 @@ struct {
         STDCONF ("basicauth", ALNUM WS ALNUM, handle_basicauth),
         STDCONF ("errorfile", INT WS STR, handle_errorfile),
         STDCONF ("addheader",  STR WS STR, handle_addheader),
+        STDCONF ("allowupgrade", BOOL, handle_allowupgrade),
 
 #ifdef FILTER_ENABLE
         /* filtering */
@@ -951,6 +953,12 @@ static HANDLE_FUNC (handle_addheader)
 
         return 0;
 }
+
+static HANDLE_FUNC (handle_allowupgrade)
+{
+        return set_bool_arg (&conf->allowupgrade, line, &match[2]);
+}
+
 
 /*
  * Log level's strings.

--- a/src/conf.h
+++ b/src/conf.h
@@ -111,6 +111,14 @@ struct config_s {
          * Extra headers to be added to outgoing HTTP requests.
          */
         vector_t add_headers;
+
+        /*
+         * Allow Upgrade and Connection headers to pass through proxy.
+         * Enables unencrypted WebSocket connections violates RFC
+         * requirements of not passing Connection/Upgrade through a
+         * proxy.  Unexpected behavior may result.
+         */
+        unsigned int allowupgrade;      /* boolean */
 };
 
 extern int reload_config_file (const char *config_fname, struct config_s *conf,

--- a/src/reqs.c
+++ b/src/reqs.c
@@ -309,7 +309,7 @@ establish_http_connection (struct conn_s *connptr, struct request_s *request)
                 /* Allow websockets to not be closed after handshake. */
                 return write_message (connptr->server_fd,
                                       "%s %s HTTP/1.0\r\n"
-                                      "Host: %s%s\r\n"
+                                      "Host: %s%s\r\n",
                                       request->method, request->path,
                                       request->host, portbuff);
         } else {


### PR DESCRIPTION
Per my comment on #101 

Still having mild issues with the configuration file option doing what is expected.  Let me know if I should move the lists of headers in `reqs.h`, how to not warn on my bad pointer casting at compile time, or any other style or bad things I'm doing.

Thank you for working on such an awesomely readable little proxy!  I really enjoyed the process of re-visiting C.