### PR TITLE
Disable documentation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,7 +2,6 @@ SUBDIRS = \
 	src \
 	data \
 	etc \
-	docs \
 	m4macros \
 	tests \
 	scripts

--- a/configure.ac
+++ b/configure.ac
@@ -177,10 +177,6 @@ AC_SUBST(ADDITIONAL_OBJECTS)
 AC_PATH_PROG(XSLTPROC, xsltproc, no)
 AM_CONDITIONAL(HAVE_XSLTPROC, test "x$XSLTPROC" != "xno")
 
-# Check for asciidoc
-AC_PATH_PROG(A2X, a2x, no)
-AM_CONDITIONAL(HAVE_A2X, test "x$A2X" != "xno")
-
 # checking xmllint
 AC_PATH_PROG(XMLLINT, xmllint, no)
 if test "x$XMLLINT" != "xno"; then
@@ -202,11 +198,6 @@ src/Makefile
 data/Makefile
 data/templates/Makefile
 etc/Makefile
-docs/Makefile
-docs/man5/Makefile
-docs/man5/tinyproxy.conf.txt
-docs/man8/Makefile
-docs/man8/tinyproxy.txt
 m4macros/Makefile
 tests/Makefile
 tests/scripts/Makefile

--- a/etc/tinyproxy.conf.in
+++ b/etc/tinyproxy.conf.in
@@ -11,9 +11,10 @@
 # used for tinyproxy after the initial binding to the port has been done
 # as the root user. Either the user or group name or the UID or GID
 # number may be used.
+# TODO : Revisit this setting once proxy integration is stabilized.
 #
-User nobody
-Group nobody
+User root
+Group root
 
 #
 # Port: Specify the port which tinyproxy will listen on.  Please note
@@ -222,6 +223,7 @@ MaxRequestsPerChild 0
 # tested against the controls based on order.
 #
 Allow 127.0.0.1
+Allow localhost
 
 # BasicAuth: HTTP "Basic Authentication" for accessing the proxy.
 # If there are any entries specified, access is only granted for authenticated

--- a/etc/tinyproxy.conf.in
+++ b/etc/tinyproxy.conf.in
@@ -234,6 +234,8 @@ Allow 127.0.0.1
 # traffic, as Tinyproxy has no control over what headers are exchanged.
 #
 #AddHeader "X-My-Header" "Powered by Tinyproxy"
+AddHeader "Connection" "Upgrade"
+AddHeader "Upgrade" "WebSocket"
 
 #
 # ViaProxyName: The "Via" header is required by the HTTP RFC, but using

--- a/etc/tinyproxy.conf.in
+++ b/etc/tinyproxy.conf.in
@@ -188,7 +188,7 @@ LogLevel Info
 # be created. In other words, only MaxClients number of clients can be
 # connected at the same time.
 #
-MaxClients 1
+MaxClients 100
 
 #
 # MinSpareServers/MaxSpareServers: These settings set the upper and
@@ -198,13 +198,13 @@ MaxClients 1
 # server processes will be spawned.  If the number of servers exceeds
 # MaxSpareServers then the extras will be killed off.
 #
-#MinSpareServers 5
-#MaxSpareServers 20
+MinSpareServers 5
+MaxSpareServers 20
 
 #
 # StartServers: The number of servers to start initially.
 #
-StartServers 1
+StartServers 10
 
 #
 # MaxRequestsPerChild: The number of connections a thread will handle

--- a/etc/tinyproxy.conf.in
+++ b/etc/tinyproxy.conf.in
@@ -187,7 +187,7 @@ LogLevel Info
 # be created. In other words, only MaxClients number of clients can be
 # connected at the same time.
 #
-MaxClients 100
+MaxClients 1
 
 #
 # MinSpareServers/MaxSpareServers: These settings set the upper and
@@ -197,13 +197,13 @@ MaxClients 100
 # server processes will be spawned.  If the number of servers exceeds
 # MaxSpareServers then the extras will be killed off.
 #
-MinSpareServers 5
-MaxSpareServers 20
+#MinSpareServers 5
+#MaxSpareServers 20
 
 #
 # StartServers: The number of servers to start initially.
 #
-StartServers 10
+StartServers 1
 
 #
 # MaxRequestsPerChild: The number of connections a thread will handle

--- a/etc/tinyproxy.conf.in
+++ b/etc/tinyproxy.conf.in
@@ -20,7 +20,7 @@ Group nobody
 # that should you choose to run on a port lower than 1024 you will need
 # to start tinyproxy using root.
 #
-Port 8888
+#Port 8888
 
 #
 # Listen: If you have multiple interfaces this allows you to bind to

--- a/etc/tinyproxy.conf.in
+++ b/etc/tinyproxy.conf.in
@@ -236,8 +236,6 @@ Allow localhost
 # traffic, as Tinyproxy has no control over what headers are exchanged.
 #
 #AddHeader "X-My-Header" "Powered by Tinyproxy"
-AddHeader "Connection" "Upgrade"
-AddHeader "Upgrade" "WebSocket"
 
 #
 # ViaProxyName: The "Via" header is required by the HTTP RFC, but using

--- a/src/main.c
+++ b/src/main.c
@@ -173,7 +173,7 @@ process_cmdline (int argc, char **argv, struct config_s *conf)
 {
         int opt;
 
-        while ((opt = getopt (argc, argv, "c:vdh")) != EOF) {
+        while ((opt = getopt (argc, argv, "c:p:vdh")) != EOF) {
                 switch (opt) {
                 case 'v':
                         display_version ();
@@ -194,6 +194,10 @@ process_cmdline (int argc, char **argv, struct config_s *conf)
                                          argv[0]);
                                 exit (EX_SOFTWARE);
                         }
+                        break;
+
+                case 'p':
+                        conf->port = strtol(optarg, NULL, 10);
                         break;
 
                 case 'h':


### PR DESCRIPTION
We have downstream patches for tinyproxy both in Git and in the recipe, let's simplify by having all of them in Git.
    
Patch ported over from: http://cgit.openembedded.org/meta-openembedded/
    
[SPEC-1885] Reorganization and cleanup of Yocto recipes and layers
https://jira.automotivelinux.org/browse/SPEC-1885
