### PR TITLE
child.c: properly initialize fdset for each select() call

### DIFF
--- a/src/child.c
+++ b/src/child.c
@@ -206,26 +206,26 @@ static void child_main (struct child_s *ptr)
          * We have to wait for connections on multiple fds,
          * so use select.
          */
-
-        FD_ZERO(&rfds);
-
-        for (i = 0; i < vector_length(listen_fds); i++) {
-                int *fd = (int *) vector_getentry(listen_fds, i, NULL);
-
-                ret = socket_nonblocking(*fd);
-                if (ret != 0) {
-                        log_message(LOG_ERR, "Failed to set the listening "
-                                    "socket %d to non-blocking: %s",
-                                    fd, strerror(errno));
-                        exit(1);
-                }
-
-                FD_SET(*fd, &rfds);
-                maxfd = max(maxfd, *fd);
-        }
-
         while (!config.quit) {
+
                 int listenfd = -1;
+
+                FD_ZERO(&rfds);
+
+                for (i = 0; i < vector_length(listen_fds); i++) {
+                        int *fd = (int *) vector_getentry(listen_fds, i, NULL);
+
+                        ret = socket_nonblocking(*fd);
+                        if (ret != 0) {
+                                log_message(LOG_ERR, "Failed to set the listening "
+                                            "socket %d to non-blocking: %s",
+                                            fd, strerror(errno));
+                                exit(1);
+                        }
+
+                        FD_SET(*fd, &rfds);
+                        maxfd = max(maxfd, *fd);
+                }
 
                 ptr->status = T_WAITING;
 


### PR DESCRIPTION
it was reported that because the fdset was only initialized once,
tinyproxy would fail to properly listen on more than one interface.

closes #214
closes #127