### PR TITLE
log failure in filter reload, use lowered permissions on initial filter-read

### DIFF
--- a/src/child.c
+++ b/src/child.c
@@ -304,7 +304,8 @@ static void child_main (struct child_s *ptr)
                  * Make sure no error occurred...
                  */
                 if (connfd < 0) {
-                        log_message (LOG_ERR,
+                        if (errno != EAGAIN)    /* do not spam the logs */
+                            log_message (LOG_ERR,
                                      "Accept returned an error (%s) ... retrying.",
                                      strerror (errno));
                         continue;

--- a/src/filter.c
+++ b/src/filter.c
@@ -61,7 +61,9 @@ void filter_init (void)
 
         fd = fopen (config.filter, "r");
         if (!fd) {
-                return;
+		log_message(LOG_ERR, "Can't read the filter from %s: %s",
+		    config.filter, strerror(errno));
+		exit(3);
         }
 
         p = NULL;

--- a/src/main.c
+++ b/src/main.c
@@ -50,6 +50,7 @@
 struct config_s config;
 struct config_s config_defaults;
 unsigned int received_sighup = FALSE;   /* boolean */
+extern volatile int children;		/* defined in child.c */
 
 /*
  * Handle a signal
@@ -373,11 +374,6 @@ main (int argc, char **argv)
                          argv[0]);
                 exit (EX_OSERR);
         }
-
-#ifdef FILTER_ENABLE
-        if (config.filter)
-                filter_init ();
-#endif /* FILTER_ENABLE */
 
         /* Start listening on the selected port. */
         if (child_listening_sockets(config.listen_addrs, config.port) < 0) {


### PR DESCRIPTION
There is a long standing bug entry in the Debian packaged tinyproxy (Debian #756040).
I fixed this some years ago and I believe, the fix could be included in the upstream source.

Old behaviour:
Tinyproxy read the config and the filter file with the startup permissions (usually root).
After a HUP (reload), e.g. issued after regular logrotate, the child processes ran with lowered permissions and - depending on the perms of the filter file - they couldn't re-read the filter. And they didn't even iussed a notice about that failure.

New behaviour:
Read the filter definition *after* changing the uid of the tinyproxy processes, *and* write a log message there is a failure in reading the filter definition.
