### PR TITLE
basic auth config: allow same chars as in upstream config

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -223,7 +223,7 @@ struct {
                  handle_deny),
         STDCONF (bind, "(" IP "|" IPV6 ")", handle_bind),
         /* other */
-        STDCONF (basicauth, ALNUM WS ALNUM, handle_basicauth),
+        STDCONF (basicauth, USERNAME WS PASSWORD, handle_basicauth),
         STDCONF (errorfile, INT WS STR, handle_errorfile),
         STDCONF (addheader,  STR WS STR, handle_addheader),
 


### PR DESCRIPTION
the character set for username and password was limited to alphanumeric
only in the past.

closes #229