### PR TITLE
filter: Don't ignore lines with leading whitespace

### DIFF
--- a/src/filter.c
+++ b/src/filter.c
@@ -78,6 +78,9 @@ void filter_init (void)
                  * comments.
                  */
                 s = buf;
+				/* skip leading whitespace */
+				while (*s && isspace ((unsigned char) *s))
+					++s;
                 while (*s) {
                         if (isspace ((unsigned char) *s))
                                 break;


### PR DESCRIPTION
This patch is related to parsing the filter file.
The new code skips leading whitespaces before removing trailing
whitespaces and comments.
Without doing this, lines with leading whitespace are treated like empty
lines (i.e. they are ignored).