### PR TITLE
Fixes #256 Provides ::1 as allowed

### DIFF
--- a/etc/tinyproxy.conf.in
+++ b/etc/tinyproxy.conf.in
@@ -222,6 +222,7 @@ MaxRequestsPerChild 0
 # tested against the controls based on order.
 #
 Allow 127.0.0.1
+Allow ::1
 
 # BasicAuth: HTTP "Basic Authentication" for accessing the proxy.
 # If there are any entries specified, access is only granted for authenticated


### PR DESCRIPTION
Add the ::1 as 'allowed' in addition to 127.0.0.1, to deal with hosts that use IPv6 by default for localhost (such as on macOS 10.14.x and some Linux distros).