### PR TITLE
Add ProxiedHost and ProxiedPort options.

### DIFF
--- a/docs/man5/tinyproxy.conf.txt.in
+++ b/docs/man5/tinyproxy.conf.txt.in
@@ -342,6 +342,11 @@ ReversePath "/example/" "http://www.example.com/"
     types into his/her browser).  If this option is not set then
     no rewriting of redirects occurs.
 
+*ProxiedHost*::
+*ProxiedPort*::
+
+    The host name and the port to which all requests from clients
+    are sent. If ProxiedHost is set, ProxiedPort must be set, too.
 
 BUGS
 ----

--- a/etc/tinyproxy.conf.in
+++ b/etc/tinyproxy.conf.in
@@ -346,5 +346,9 @@ ViaProxyName "tinyproxy"
 #
 #ReverseBaseURL "http://localhost:8888/"
 
-
-
+#
+# The host and port to which all requests are sent.
+# If ProxiedHost is set, ProxiedPort must be set.
+#
+#ProxiedHost "some.proxied.host.com"
+#ProxiedPort 8080

--- a/src/conf.h
+++ b/src/conf.h
@@ -1,6 +1,7 @@
 /* tinyproxy - A fast light-weight HTTP proxy
  * Copyright (C) 2004 Robert James Kaes <rjkaes@users.sourceforge.net>
  * Copyright (C) 2009 Michael Adam <obnox@samba.org>
+ * Copyright (C) 2019 Kaito Yamada <kaitoy@pcap4j.org>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -111,6 +112,13 @@ struct config_s {
          * Extra headers to be added to outgoing HTTP requests.
          */
         vector_t add_headers;
+
+        /*
+         * The proxied host and port.
+         * All requests are sent to it regardless of their original destination.
+         */
+        char *proxied_host;
+        unsigned int proxied_port;
 };
 
 extern int reload_config_file (const char *config_fname, struct config_s *conf,

--- a/src/reqs.c
+++ b/src/reqs.c
@@ -3,6 +3,7 @@
  * Copyright (C) 1999-2005 Robert James Kaes <rjkaes@users.sourceforge.net>
  * Copyright (C) 2000 Chris Lightfoot <chris@ex-parrot.com>
  * Copyright (C) 2002 Petr Lampa <lampa@fit.vutbr.cz>
+ * Copyright (C) 2019 Kaito Yamada <kaitoy@pcap4j.org>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1679,8 +1680,13 @@ e401:
                         goto fail;
                 }
         } else {
-                connptr->server_fd = opensock (request->host, request->port,
-                                               connptr->server_ip_addr);
+                if (config.proxied_host) {
+                        connptr->server_fd = opensock (config.proxied_host, config.proxied_port,
+                                                       connptr->server_ip_addr);
+                } else {
+                        connptr->server_fd = opensock (request->host, request->port,
+                                                       connptr->server_ip_addr);
+                }
                 if (connptr->server_fd < 0) {
                         indicate_http_error (connptr, 500, "Unable to connect",
                                              "detail",


### PR DESCRIPTION
ProxiedHost and ProxiedPort are to specify an endpoint which all requests from clients are forward to regardless of their original destination URLs.
These options are useful for testing some clients with mock servers, for example.