### PR TITLE
fix check_acl: compile failure due to undefined variable 'host'

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -344,7 +344,7 @@ int check_acl (const char *ip, union sockaddr_union *addr, vector_t access_list)
         char string_addr[HOSTNAME_LENGTH];
 
         assert (ip != NULL);
-        assert (host != NULL);
+        assert (addr != NULL);
 
         string_addr[0] = 0;
 


### PR DESCRIPTION
```
make  all-recursive
make[1]: Entering directory '/data00/home/tinyproxy'
Making all in src
make[2]: Entering directory '/data00/home/tinyproxy/src'
  CC       acl.o
In file included from common.h:67:0,
                 from main.h:25,
                 from acl.c:24:
acl.c: In function ‘check_acl’:
acl.c:347:17: error: ‘host’ undeclared (first use in this function)
         assert (host != NULL);
                 ^
acl.c:347:17: note: each undeclared identifier is reported only once for each function it appears in
Makefile:452: recipe for target 'acl.o' failed
```