### PR TITLE
add support for outgoing connections with HTTP/1.1

### DIFF
--- a/src/html-error.c
+++ b/src/html-error.c
@@ -131,7 +131,7 @@ send_html_file (FILE *infile, struct conn_s *connptr)
 int send_http_headers (struct conn_s *connptr, int code, const char *message)
 {
         const char headers[] =
-            "HTTP/1.0 %d %s\r\n"
+            "HTTP/1.%u %d %s\r\n"
             "Server: %s/%s\r\n"
             "Content-Type: text/html\r\n"
             "%s"
@@ -150,6 +150,7 @@ int send_http_headers (struct conn_s *connptr, int code, const char *message)
         const char *add = code == 407 ? p_auth_str : (code == 401 ? w_auth_str : "");
 
         return (write_message (connptr->client_fd, headers,
+                               connptr->protocol.major != 1 ? 0 : connptr->protocol.minor,
                                code, message, PACKAGE, VERSION,
                                add));
 }

--- a/src/reqs.c
+++ b/src/reqs.c
@@ -266,28 +266,34 @@ establish_http_connection (struct conn_s *connptr, struct request_s *request)
                 /* host is an IPv6 address literal, so surround it with
                  * [] */
                 return write_message (connptr->server_fd,
-                                      "%s %s HTTP/1.0\r\n"
+                                      "%s %s HTTP/1.%u\r\n"
                                       "Host: [%s]%s\r\n"
                                       "Connection: close\r\n",
                                       request->method, request->path,
+                                      connptr->protocol.major != 1 ? 0 :
+                                               connptr->protocol.minor,
                                       request->host, portbuff);
         } else if (connptr->upstream_proxy &&
                    connptr->upstream_proxy->type == PT_HTTP &&
                    connptr->upstream_proxy->ua.authstr) {
                 return write_message (connptr->server_fd,
-                                      "%s %s HTTP/1.0\r\n"
+                                      "%s %s HTTP/1.%u\r\n"
                                       "Host: %s%s\r\n"
                                       "Connection: close\r\n"
                                       "Proxy-Authorization: Basic %s\r\n",
                                       request->method, request->path,
+                                      connptr->protocol.major != 1 ? 0 :
+                                               connptr->protocol.minor,
                                       request->host, portbuff,
                                       connptr->upstream_proxy->ua.authstr);
         } else {
                 return write_message (connptr->server_fd,
-                                      "%s %s HTTP/1.0\r\n"
+                                      "%s %s HTTP/1.%u\r\n"
                                       "Host: %s%s\r\n"
                                       "Connection: close\r\n",
                                       request->method, request->path,
+                                      connptr->protocol.major != 1 ? 0 :
+                                               connptr->protocol.minor,
                                       request->host, portbuff);
         }
 }


### PR DESCRIPTION
since there are numerous changes in HTTP/1.1, the proxyserver will
stick to using HTTP/1.0 for internal usage, however when a connection
is requested with HTTP/1.x from now on we will duplicate the minor revision
the client requested, because apparently some servers refuse to accept
HTTP/1.0

addresses #152.