### PR TITLE
Change loglevel for "Maximum number of connections reached"

### DIFF
--- a/src/child.c
+++ b/src/child.c
@@ -100,7 +100,7 @@ void child_main_loop (void)
 
                 if (sblist_getsize(childs) >= config->maxclients) {
                         if (!was_full)
-                                log_message (LOG_NOTICE,
+                                log_message (LOG_WARNING,
                                              "Maximum number of connections reached. "
                                              "Refusing new connections.");
                         was_full = 1;


### PR DESCRIPTION
I was hit by this, and did not see anything in the log, connections was just hanging.
Think "warning" is a better log level