### PR TITLE
Added BasicAuth to tinyproxy.conf man page

### DIFF
--- a/docs/man5/tinyproxy.conf.txt.in
+++ b/docs/man5/tinyproxy.conf.txt.in
@@ -225,6 +225,14 @@ Note that by adding a rule using a host or domain name, a costly name
 lookup has to be done for every new connection, which could slow down
 the service considerably.
 
+=item B<BasicAuth>
+
+Configure HTTP "Basic Authentication" username and password
+for accessing the proxy.  If there are any entries specified,
+access is only granted for authenticated users.
+
+    BasicAuth user password
+
 =item B<AddHeader>
 
 Configure one or more HTTP request headers to be added to outgoing


### PR DESCRIPTION
Following feature added in 8db511b9bff5dfa61a9448659e28ce54d9aa8869 .

If this is good, I suppose the man text output can be synced across to the Github Pages project for website?