### PR TITLE
 update conf.c: regular expression for password #1 

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -54,7 +54,7 @@
 #define INT "((0x)?[[:digit:]]+)"
 #define ALNUM "([-a-z0-9._]+)"
 #define USERNAME "([^:]*)"
-#define PASSWORD "([^@]*)"
+#define PASSWORD "(.*)"
 #define IP "((([0-9]{1,3})\\.){3}[0-9]{1,3})"
 #define IPMASK "(" IP "(/[[:digit:]]+)?)"
 #define IPV6 "(" \


### PR DESCRIPTION
Change regular expression for password from `[^@]*` to `.*` this matches all characters including the @ character.

Tested with an upstream squid proxy which enforces basic authentication.
I used the following username password combinations to test the following config directives (in a few permutations/combinations)
```
upstream http proxy:proxy@10.10.20.50:3128
upstream http proxy:proxy@10.10.20.50:3128 "google.com"
upstream http userame:p@ssword@10.10.20.50:3128
upstream http userame:p@ssword@10.10.20.50:3128 "google.com"
upstream http allspecial:ALL~`!@#$%^&*()'_+-={}|\][;"ALL@10.10.20.50:3128
upstream http allspecial:ALL~`!@#$%^&*()'_+-={}|\][;"ALL@10.10.20.50:3128 "google.com"
upstream http proxy:proxy@proxy.test.com:3128
upstream http proxy:proxy@proxy.test.com:3128 "google.com"
upstream http userame:p@ssword@proxy.test.com:3128
upstream http userame:p@ssword@proxy.test.com:3128 "google.com"
upstream http allspecial:ALL~`!@#$%^&*()'_+-={}|\][;"ALL@proxy.test.com:3128
upstream http allspecial:ALL~`!@#$%^&*()'_+-={}|\][;"ALL@proxy.test.com:3128 "google.com"
```
