### PR TITLE
Allow multiple Bind directives.

### DIFF
--- a/docs/man5/tinyproxy.conf.txt.in
+++ b/docs/man5/tinyproxy.conf.txt.in
@@ -58,6 +58,8 @@ only on one specific address.
 
 This allows you to specify which address Tinyproxy will bind
 to for outgoing connections to web servers or upstream proxies.
+This parameter may be specified multiple times, then Tinyproxy
+will try all the specified addresses in order.
 
 =item B<BindSame>
 

--- a/src/conf.h
+++ b/src/conf.h
@@ -68,7 +68,7 @@ struct config_s {
 #endif                          /* UPSTREAM_SUPPORT */
         char *pidpath;
         unsigned int idletimeout;
-        char *bind_address;
+        sblist *bind_addrs;
         unsigned int bindsame;
 
         /*

--- a/src/sock.c
+++ b/src/sock.c
@@ -68,7 +68,7 @@ bind_socket (int sockfd, const char *addr, int family)
         n = getaddrinfo (addr, NULL, &hints, &res);
         if (n != 0) {
                 log_message (LOG_INFO,
-                        "bind_socket: getaddrinfo failed for %s: ", addr, get_gai_error (n));
+                        "bind_socket: getaddrinfo failed for %s: %s", addr, get_gai_error (n));
                 return -1;
         }
 


### PR DESCRIPTION
Try all the addresses specified with Bind in order. This is necessary
e.g. for maintaining IPv4+6 connectivity while still being restricted to
one interface.