### PR TITLE
reverse: redirect if path without trailing slash is detected

### DIFF
--- a/src/reqs.c
+++ b/src/reqs.c
@@ -389,8 +389,8 @@ BAD_REQUEST_ERROR:
 
                 if (reverse_url != NULL) {
                         if (reverse_status == 301) {
-				char buf[PATH_MAX];
-				snprintf(buf, sizeof buf, "Location: %s\r\n", reverse_url);
+                                char buf[PATH_MAX];
+                                snprintf (buf, sizeof buf, "Location: %s\r\n", reverse_url);
                                 send_http_headers (connptr, 301, "Moved Permanently", buf);
                                 goto fail;
                         }

--- a/src/reqs.c
+++ b/src/reqs.c
@@ -383,10 +383,17 @@ BAD_REQUEST_ERROR:
                  * we'll be closing anyway.
                  */
                 char *reverse_url;
+                int reverse_status;
 
-                reverse_url = reverse_rewrite_url (connptr, hashofheaders, url);
+                reverse_url = reverse_rewrite_url (connptr, hashofheaders, url, &reverse_status);
 
                 if (reverse_url != NULL) {
+                        if (reverse_status == 301) {
+				char buf[PATH_MAX];
+				snprintf(buf, sizeof buf, "Location: %s\r\n", reverse_url);
+                                send_http_headers (connptr, 301, "Moved Permanently", buf);
+                                goto fail;
+                        }
                         safefree (url);
                         url = reverse_url;
                 } else if (config->reverseonly) {

--- a/src/reverse-proxy.h
+++ b/src/reverse-proxy.h
@@ -38,6 +38,7 @@ extern struct reversepath *reversepath_get (char *url,
                                             struct reversepath *reverse);
 void free_reversepath_list (struct reversepath *reverse);
 extern char *reverse_rewrite_url (struct conn_s *connptr,
-                                  orderedmap hashofheaders, char *url);
+                                  orderedmap hashofheaders, char *url,
+                                  int *status);
 
 #endif


### PR DESCRIPTION
if for example:

ReversePath = "/foo/"

and user requests "http://tinyproxy/foo" the common behaviour for HTTP
servers is to send a http 301 redirect to the correct url.
we now do the same.