### PR TITLE
Mm rdns

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -102,13 +102,13 @@ if test x"$transparent_enabled" = x"yes"; then
 fi
 
 dnl Include support for reverse dns to match IP network/mask ?
-AH_TEMPLATE([RDNS_ENABLE],
-	    [Include support for reverse dns to match IP network/mask. This is best used with nscd enabled to minimise DNS resolution delays])
+AH_TEMPLATE([FDNS_ENABLE],
+	    [Include support for forward dns to match IP network/mask. This is best used with nscd enabled to minimise DNS resolution delays])
 TP_ARG_ENABLE(rdns,
-	      [Enable support for reverse dns to match IP network/mask (default is NO)],
+	      [Enable support for forward dns to match IP network/mask (default is NO)],
 	      no)
-if test x"$rdns__enabled" = x"yes"; then
-   AC_DEFINE(RDNS_ENABLE)
+if test x"$fdns__enabled" = x"yes"; then
+   AC_DEFINE(FDNS_ENABLE)
 fi
 
 dnl Let user decide whether he wants support for manpages

--- a/configure.ac
+++ b/configure.ac
@@ -101,6 +101,16 @@ if test x"$transparent_enabled" = x"yes"; then
    AC_DEFINE(TRANSPARENT_PROXY)
 fi
 
+dnl Include support for reverse dns to match IP network/mask ?
+AH_TEMPLATE([RDNS_ENABLE],
+	    [Include support for reverse dns to match IP network/mask.])
+TP_ARG_ENABLE(rdns,
+	      [Enable support for reverse dns to match IP network/mask (default is YES)],
+	      yes)
+if test x"$rdns__enabled" = x"yes"; then
+   AC_DEFINE(RDNS_ENABLE)
+fi
+
 dnl Let user decide whether he wants support for manpages
 dnl Which require either pod2man or a tarball release
 AH_TEMPLATE([MANPAGE_SUPPORT],

--- a/configure.ac
+++ b/configure.ac
@@ -103,7 +103,7 @@ fi
 
 dnl Include support for reverse dns to match IP network/mask ?
 AH_TEMPLATE([RDNS_ENABLE],
-	    [Include support for reverse dns to match IP network/mask.])
+	    [Include support for reverse dns to match IP network/mask. This is best used with nscd enabled to minimise DNS resolution delays])
 TP_ARG_ENABLE(rdns,
 	      [Enable support for reverse dns to match IP network/mask (default is NO)],
 	      no)

--- a/configure.ac
+++ b/configure.ac
@@ -105,8 +105,8 @@ dnl Include support for reverse dns to match IP network/mask ?
 AH_TEMPLATE([RDNS_ENABLE],
 	    [Include support for reverse dns to match IP network/mask.])
 TP_ARG_ENABLE(rdns,
-	      [Enable support for reverse dns to match IP network/mask (default is YES)],
-	      yes)
+	      [Enable support for reverse dns to match IP network/mask (default is NO)],
+	      no)
 if test x"$rdns__enabled" = x"yes"; then
    AC_DEFINE(RDNS_ENABLE)
 fi

--- a/docs/man5/tinyproxy.conf.txt.in
+++ b/docs/man5/tinyproxy.conf.txt.in
@@ -200,6 +200,7 @@ Note that the upstream directive can also be used to null-route
 a specific target domain/host, e.g.:
 `upstream http 0.0.0.0:0 ".adserver.com"`
 
+With RDNS enabled the site's IP address will also be matched against the <IP/bits> or <IP/mask> values in addition to the name or domain match
 =item B<MaxClients>
 
 Tinyproxy creates one thread for each connected client.

--- a/docs/man5/tinyproxy.conf.txt.in
+++ b/docs/man5/tinyproxy.conf.txt.in
@@ -200,7 +200,7 @@ Note that the upstream directive can also be used to null-route
 a specific target domain/host, e.g.:
 `upstream http 0.0.0.0:0 ".adserver.com"`
 
-With RDNS enabled the site's IP address will also be matched against the <IP/bits> or <IP/mask> values in addition to the name or domain match
+With FDNS enabled the site's IP address will also be matched against the <IP/bits> or <IP/mask> values in addition to the name or domain match
 =item B<MaxClients>
 
 Tinyproxy creates one thread for each connected client.

--- a/src/hostspec.c
+++ b/src/hostspec.c
@@ -15,15 +15,6 @@ static int dotted_mask(char *bitmask_string, unsigned char array[])
 	return 0;
 }
 
-static int dotted_mask(char *bitmask_string, unsigned char array[])
-{
-	unsigned char v4bits[4];
-	if (1 != inet_pton (AF_INET, bitmask_string, v4bits)) return -1;
-	memset (array, 0xff, IPV6_LEN-4);
-	memcpy (array + IPV6_LEN-4, v4bits, 4);
-	return 0;
-}
-
 /*
  * Fills in the netmask array given a numeric value.
  *

--- a/src/hostspec.c
+++ b/src/hostspec.c
@@ -176,7 +176,7 @@ static int reverse_dns_numeric_match(const char *ip, const struct hostspec *h)
 
 	ressave = res; 
 
-        if (ret != 0) {
+	if (ret != 0) {
 		if (ret == EAI_SYSTEM)
 			log_message (LOG_ERR, "Could not retrieve address info for %s : %s",ip,strerror(errno));
 		else

--- a/src/hostspec.c
+++ b/src/hostspec.c
@@ -2,7 +2,7 @@
 #include "hostspec.h"
 #include "heap.h"
 #include "network.h"
-#ifdef RDNS_ENABLE
+#ifdef FDNS_ENABLE
 #include "log.h"
 #endif
 
@@ -162,8 +162,8 @@ static int numeric_match(const uint8_t addr[], const struct hostspec *h)
 	return 1;
 }
 
-#ifdef RDNS_ENABLE
-static int reverse_dns_numeric_match(const char *ip, const struct hostspec *h)
+#ifdef FDNS_ENABLE
+static int dns_numeric_match(const char *ip, const struct hostspec *h)
 {
 	int ret;
 	struct addrinfo *res, *ressave;
@@ -210,8 +210,8 @@ int hostspec_match(const char *ip, const struct hostspec *h) {
 		if(is_numeric_addr) return 0;
 		return string_match (ip, h->address.string);
 	case HST_NUMERIC:
-#ifdef RDNS_ENABLE
-		if(!is_numeric_addr) return reverse_dns_numeric_match(ip, h);
+#ifdef FDNS_ENABLE
+		if(!is_numeric_addr) return dns_numeric_match(ip, h);
 #endif
 		return numeric_match (numeric_addr, h);
 	case HST_NONE:


### PR DESCRIPTION
This is a patch which allows the matching of a hostname against a subnet.

This help in internal/private networks to make sure 10.0.0.0/8 or 192.168.0.0/16 IPs go direct and not to an upstream proxy.

Markus