### PR TITLE
Fix FTBFS on hurd-i386: run_tests.sh duplicates build path.

### DIFF
--- a/tests/scripts/run_tests.sh
+++ b/tests/scripts/run_tests.sh
@@ -18,7 +18,7 @@
 # this program; if not, see <http://www.gnu.org/licenses/>.
 
 
-SCRIPTS_DIR=$(pwd)/$(dirname $0)
+SCRIPTS_DIR=$(cd $(dirname $0) && pwd)
 BASEDIR=$SCRIPTS_DIR/../..
 TESTS_DIR=$SCRIPTS_DIR/..
 TESTENV_DIR=$TESTS_DIR/env


### PR DESCRIPTION
Howdy,

It seems tinyproxy failed to build on hurd-i386 and a patch was contributed to solve that issue, this is said patch.