### PR TITLE
Return 5xx when upstream is unreachable

### DIFF
--- a/etc/tinyproxy.conf.in
+++ b/etc/tinyproxy.conf.in
@@ -56,8 +56,8 @@ Timeout 600
 #   /usr/share/tinyproxy
 #   /etc/tinyproxy
 #
-#ErrorFile 404 "@pkgdatadir@/404.html"
 #ErrorFile 400 "@pkgdatadir@/400.html"
+#ErrorFile 502 "@pkgdatadir@/502.html"
 #ErrorFile 503 "@pkgdatadir@/503.html"
 #ErrorFile 403 "@pkgdatadir@/403.html"
 #ErrorFile 408 "@pkgdatadir@/408.html"

--- a/src/reqs.c
+++ b/src/reqs.c
@@ -1424,7 +1424,7 @@ connect_to_upstream (struct conn_s *connptr, struct request_s *request)
                 log_message (LOG_WARNING,
                              "No upstream proxy defined for %s.",
                              request->host);
-                indicate_http_error (connptr, 404,
+                indicate_http_error (connptr, 502,
                                      "Unable to connect to upstream proxy.");
                 return -1;
         }
@@ -1436,7 +1436,7 @@ connect_to_upstream (struct conn_s *connptr, struct request_s *request)
         if (connptr->server_fd < 0) {
                 log_message (LOG_WARNING,
                              "Could not connect to upstream proxy.");
-                indicate_http_error (connptr, 404,
+                indicate_http_error (connptr, 502,
                                      "Unable to connect to upstream proxy",
                                      "detail",
                                      "A network error occurred while trying to "

--- a/tests/scripts/run_tests.sh
+++ b/tests/scripts/run_tests.sh
@@ -83,6 +83,7 @@ DefaultErrorFile "$TINYPROXY_DATA_DIR/debug.html"
 ErrorFile 400 "$TINYPROXY_DATA_DIR/debug.html"
 ErrorFile 403 "$TINYPROXY_DATA_DIR/debug.html"
 ErrorFile 501 "$TINYPROXY_DATA_DIR/debug.html"
+ErrorFile 502 "$TINYPROXY_DATA_DIR/debug.html"
 StatFile "$TINYPROXY_DATA_DIR/stats.html"
 Logfile "$TINYPROXY_LOG_FILE"
 PidFile "$TINYPROXY_PID_FILE"
@@ -99,6 +100,7 @@ XTinyproxy Yes
 AddHeader "X-My-Header1" "Powered by Tinyproxy"
 AddHeader "X-My-Header2" "Powered by Tinyproxy"
 AddHeader "X-My-Header3" "Powered by Tinyproxy"
+Upstream http 255.255.255.255:65535 ".invalid"
 EOF
 
 cat << 'EOF' > $TINYPROXY_FILTER_FILE
@@ -243,6 +245,10 @@ test "x$?" = "x0" || FAILED=$((FAILED + 1))
 
 echo -n "requesting connect method to denied port..."
 run_failure_webclient_request 403 --method=CONNECT "$TINYPROXY_IP:$TINYPROXY_PORT" "localhost:12345"
+test "x$?" = "x0" || FAILED=$((FAILED + 1))
+
+echo -n "testing unavailable backend..."
+run_failure_webclient_request 502 "$TINYPROXY_IP:$TINYPROXY_PORT" "http://bogus.invalid"
 test "x$?" = "x0" || FAILED=$((FAILED + 1))
 }
 


### PR DESCRIPTION
Currently a 404 is returned for a misconfigured or unavailable upstream server.  Since that's a server error it should be a 5xx instead; a 404 is confusing when used as a forward proxy and might even be harmful when used as a reverse proxy.

It is debatable if another 5xx code might be better; the misconfigured situation might better be a 500 whereas the connection issue could be a 503 instead (as used eg. in haproxy).