### PR TITLE
fix timeout not being applied to outgoing connections

### DIFF
--- a/src/reqs.c
+++ b/src/reqs.c
@@ -1517,6 +1517,9 @@ static void handle_connection_failure(struct conn_s *connptr, int got_headers)
  * when we start the relay portion. This makes most of the original
  * tinyproxy code, which was confusing, redundant. Hail progress.
  * 	- rjkaes
+
+ * this function is called directly from child_thread() with the newly
+ * received fd from accept(). 
  */
 void handle_connection (struct conn_s *connptr, union sockaddr_union* addr)
 {
@@ -1528,7 +1531,6 @@ void handle_connection (struct conn_s *connptr, union sockaddr_union* addr)
         int got_headers = 0, fd = connptr->client_fd;
         size_t i;
         struct request_s *request = NULL;
-        struct timeval tv;
         orderedmap hashofheaders = NULL;
 
         char sock_ipaddr[IP_LENGTH];
@@ -1550,12 +1552,7 @@ void handle_connection (struct conn_s *connptr, union sockaddr_union* addr)
                 return;
         }
 
-        tv.tv_usec = 0;
-        tv.tv_sec = config->idletimeout;
-        setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, (void*) &tv, sizeof(tv));
-        tv.tv_usec = 0;
-        tv.tv_sec = config->idletimeout;
-        setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, (void*) &tv, sizeof(tv));
+        set_socket_timeout(fd);
 
         if (connection_loops (addr))  {
                 log_message (LOG_CONN,

--- a/src/sock.c
+++ b/src/sock.c
@@ -108,6 +108,16 @@ bind_socket_list (int sockfd, sblist *addresses, int family)
         return -1;
 }
 
+void set_socket_timeout(int fd) {
+        struct timeval tv;
+        tv.tv_usec = 0;
+        tv.tv_sec = config->idletimeout;
+        setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, (void*) &tv, sizeof(tv));
+        tv.tv_usec = 0;
+        tv.tv_sec = config->idletimeout;
+        setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, (void*) &tv, sizeof(tv));
+}
+
 /*
  * Open a connection to a remote host.  It's been re-written to use
  * the getaddrinfo() library function, which allows for a protocol
@@ -162,6 +172,8 @@ int opensock (const char *host, int port, const char *bind_to)
                                 continue;       /* can't bind, so try again */
                         }
                 }
+
+                set_socket_timeout(sockfd);
 
                 if (connect (sockfd, res->ai_addr, res->ai_addrlen) == 0) {
                         union sockaddr_union *p = (void*) res->ai_addr, u;

--- a/src/sock.h
+++ b/src/sock.h
@@ -56,6 +56,8 @@ extern int listen_sock (const char *addr, uint16_t port, sblist* listen_fds);
 extern int socket_nonblocking (int sock);
 extern int socket_blocking (int sock);
 
+extern void set_socket_timeout(int fd);
+
 extern int getsock_ip (int fd, char *ipaddr);
 extern void getpeer_information (union sockaddr_union *addr, char *ipaddr, size_t ipaddr_len);
 


### PR DESCRIPTION
the fix in 0b9a74c29036f9215b2b97a301b7b25933054302 was incomplete, as it
applied the socket timeout only to the socket received from accept(), but
not to sockets created for outgoing connections.