### PR TITLE
Adding stats template with JSON output

### DIFF
--- a/data/templates/Makefile.am
+++ b/data/templates/Makefile.am
@@ -3,7 +3,8 @@ templatesdir = $(pkgdatadir)
 TEMPLATES = \
 	debug.html \
 	default.html \
-	stats.html
+	stats.html \
+	stats-json.html
 
 templates_DATA = \
 	$(TEMPLATES)

--- a/data/templates/stats-json.html
+++ b/data/templates/stats-json.html
@@ -1,0 +1,1 @@
+{{ "version":"{version}", "open":{opens}, "requests":{reqs}, "bad":{badconns}, "denied":{deniedconns}, "refused":{refusedconns} }


### PR DESCRIPTION
This PR adds a very simple yet useful stats template with JSON output. 
HTML formatting is not required for a pure JSON output.
The first curly brace is set "twice" on purpose, otherwise Tinyproxy itself thinks a variable needs to be parsed. 

Works fine in my environment with version 1.10.0 on Debian Bullseye:

```
ck@linux:~# grep StatFile /etc/tinyproxy/tinyproxy.conf 
# StatFile: The HTML file that gets sent when a request is made
StatFile "/usr/share/tinyproxy/stats-json.html"

ck@linux:~# curl -H "Host: tinyproxy.stats" http://127.0.0.1:8888
{ "version":"1.10.0", "open":1, "requests":267, "bad":2, "denied":2, "refused":0 }
```

