### PR TITLE
Added support to for SO_BINDTODEVICE on listening socket

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -64,6 +64,7 @@
 #define ALNUM "([-a-z0-9._]+)"
 #define USERNAME "([^:]*)"
 #define PASSWORD "([^@]*)"
+#define INTERFACE "[^ \t\\/]{1,16}"
 #define IP "((([0-9]{1,3})\\.){3}[0-9]{1,3})"
 #define IPMASK "(" IP "(/" DIGIT "+)?)"
 #define IPV6 "(" \
@@ -217,7 +218,11 @@ struct {
         STDCONF (user, ALNUM, handle_user),
         STDCONF (group, ALNUM, handle_group),
         /* ip arguments */
-        STDCONF (listen, "(" IP "|" IPV6 ")", handle_listen),
+        STDCONF (listen, "(" IP "|" IPV6
+#ifdef SO_BINDTODEVICE
+                        "|" INTERFACE
+#endif
+                ")", handle_listen),
         STDCONF (allow, "(" "(" IPMASK "|" IPV6MASK ")" "|" ALNUM ")",
                  handle_allow),
         STDCONF (deny, "(" "(" IPMASK "|" IPV6MASK ")" "|" ALNUM ")",


### PR DESCRIPTION
I added support to bind the listen statement to an interface, not an IP address. The backgroubnd is IPv6, where I have trouble binding to all IPv6 adresses of an inferface on boot, because the IPv6 adresses are not usabel, yet.

With this pull-request the listen-statement in the config file accepts an interface name and tinyproxy does setsockopt(SO_BINDTODEVICE) on the interface to bind the socket to an interface.