### PR TITLE
configure: fix check for valid compiler flags with Clang

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -156,12 +156,12 @@ if test -n "${MAINTAINER_MODE_FALSE}"; then
 fi
 
 all_desired_work=false
-AS_COMPILER_FLAG([$DESIRED_FLAGS], [all_desired_work=true])
+AS_COMPILER_FLAG([-Werror $DESIRED_FLAGS], [all_desired_work=true])
 if $all_desired_work ; then
     CFLAGS="$CFLAGS $DESIRED_FLAGS"
 else
 for flag in $DESIRED_FLAGS; do
-  AS_COMPILER_FLAG([$flag], [CFLAGS="$CFLAGS $flag"])
+  AS_COMPILER_FLAG([-Werror $flag], [CFLAGS="$CFLAGS $flag"])
 done
 fi
 


### PR DESCRIPTION
By default Clang reports unknown compiler flags as warnings
thus the valid compiler flags check fails to work properly.
Clang needs to have -Werror passed.