### PR TITLE
ci: add Shellcheck workflow

### DIFF
--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -1,0 +1,33 @@
+name: shellcheck
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    paths-ignore:
+    branches:
+      - master
+
+# cancel the in-progress workflow when PR is refreshed.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: install shellcheck
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y shellcheck
+    - name: Run autogen
+      run: ./autogen.sh
+    - name: Run ShellCheck
+      run: make shellcheck
+

--- a/Makefile.am
+++ b/Makefile.am
@@ -27,6 +27,10 @@ EXTRA_DIST = \
 test: all
 	./tests/scripts/run_tests.sh
 
+.PHONY: shellcheck
+shellcheck:
+	@shellcheck `find . -name '*.sh'`
+
 test-wait:
 	TINYPROXY_TESTS_WAIT=yes $(MAKE) test
 

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,24 +1,31 @@
 #!/bin/sh
 
-srcdir=`dirname $0`
+srcdir=$(dirname "$0")
 test -z "$srcdir" && srcdir=.
-ORIGDIR=`pwd`
+ORIGDIR=$(pwd)
 
 set -x
 
-cd $srcdir
+cd "$srcdir" || {
+    echo "error changing to dir '$srcdir'"
+    exit
+}
 
 aclocal -I m4macros \
   && autoheader \
   && automake --gnu --add-missing \
   && autoconf
 
-cd $ORIGDIR
+cd "$ORIGDIR" || {
+    echo "error changing to idir '$ORIGDIR'"
+    exit
+
+}
 
 set -
 
-echo $srcdir/configure "$@"
-$srcdir/configure "$@"
+echo "$srcdir"/configure "$@"
+"$srcdir"/configure "$@"
 RC=$?
 if test $RC -ne 0; then
   echo

--- a/tests/scripts/run_tests.sh
+++ b/tests/scripts/run_tests.sh
@@ -146,8 +146,6 @@ start_webserver() {
 	printf "starting web server..."
 	"$WEBSERVER_BIN" --port "$WEBSERVER_PORT" --log-dir "$WEBSERVER_LOG_DIR" --pid-file "$WEBSERVER_PID_FILE"
 	echo " done. listening on $WEBSERVER_IP:$WEBSERVER_PORT"
-	"$WEBSERVER_BIN" --port "$WEBSERVER_PORT" --log-dir "$WEBSERVER_LOG_DIR" --pid-file "$WEBSERVER_PID_FILE"
-	echo " done. listening on $WEBSERVER_IP:$WEBSERVER_PORT"
 }
 
 stop_webserver() {

--- a/tests/scripts/run_tests_valgrind.sh
+++ b/tests/scripts/run_tests_valgrind.sh
@@ -18,11 +18,10 @@
 # this program; if not, see <http://www.gnu.org/licenses/>.
 
 
-SCRIPTS_DIR=$(dirname $0)
-BASEDIR=$SCRIPTS_DIR/../..
+SCRIPTS_DIR=$(dirname "$0")
 TESTS_DIR=$SCRIPTS_DIR/..
 TESTENV_DIR=$TESTS_DIR/env
 LOG_DIR=$TESTENV_DIR/var/log
 
-VALGRIND="valgrind --track-origins=yes --show-leak-kinds=all --tool=memcheck --leak-check=full --log-file=$LOG_DIR/valgrind.log" $SCRIPTS_DIR/run_tests.sh
+VALGRIND="valgrind --track-origins=yes --show-leak-kinds=all --tool=memcheck --leak-check=full --log-file=$LOG_DIR/valgrind.log" "$SCRIPTS_DIR"/run_tests.sh
 


### PR DESCRIPTION
This adds shellcheck linting to the CI.

The purpose of this is to make sure the shell scripts in this repo don't have
syntactic or style issues known to shellcheck and to prevent future PRs from introducing regressions.


It additionally fixes issues in existing scripts while at it to prevent this from breaking the CI right away.


