### PR TITLE
Fix improper vsyslog detection and conditional compilation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -146,7 +146,7 @@ AC_CHECK_HEADERS([sys/ioctl.h alloca.h memory.h malloc.h sysexits.h \
 dnl Checks for libary functions
 AC_FUNC_LSTAT_FOLLOWS_SLASHED_SYMLINK
 
-AC_CHECK_FUNCS([strlcpy strlcat setgroups])
+AC_CHECK_FUNCS([strlcpy strlcat setgroups vsyslog])
 
 dnl Enable extra warnings
 DESIRED_FLAGS="-fdiagnostics-show-option -Wall -Wextra -Wno-unused-parameter -Wmissing-prototypes -Wstrict-prototypes -Wmissing-declarations -Wfloat-equal -Wundef -Wformat=2 -Wlogical-op -Wmissing-include-dirs -Wformat-nonliteral -Wold-style-definition -Wpointer-arith -Waggregate-return -Winit-self -Wpacked --std=c89 -ansi -Wno-overlength-strings -Wno-long-long -Wno-overlength-strings -Wdeclaration-after-statement -Wredundant-decls -Wmissing-noreturn -Wshadow -Wendif-labels -Wcast-qual -Wcast-align -Wwrite-strings -Wp,-D_FORTIFY_SOURCE=2 -fno-common"

--- a/src/log.c
+++ b/src/log.c
@@ -165,7 +165,7 @@ void log_message (int level, const char *fmt, ...)
 
         if (config->syslog) {
                 pthread_mutex_lock(&log_mutex);
-#ifdef HAVE_VSYSLOG_H
+#ifdef HAVE_VSYSLOG
                 vsyslog (level, fmt, args);
 #else
                 vsnprintf (str, STRING_LENGTH, fmt, args);


### PR DESCRIPTION

### Summary

Fix a build and behavior issue in `log.c` where `vsyslog()` is conditionally compiled using an incorrect macro: `HAVE_VSYSLOG_H`.

### Problem

The current code checks for `vsyslog()` support using:

```c
#ifdef HAVE_VSYSLOG_H
    vsyslog(level, fmt, args);
```

However, `vsyslog.h` does not exist in any standard C library. Since `vsyslog()` is not part of the POSIX standard, it should be detected using Autoconf via `AC_CHECK_FUNCS`, rather than relying on a non-existent header macro.

### Fix

- **In `configure.ac`**, modified the function checks from:

  ```m4
  AC_CHECK_FUNCS([strlcpy strlcat setgroups])
  ```

  to:

  ```m4
  AC_CHECK_FUNCS([strlcpy strlcat setgroups vsyslog])
  ```

- **In `log.c`**, updated the conditional compilation to:

  ```c
  #ifdef HAVE_VSYSLOG
      vsyslog(level, fmt, args);
  ```
