### PR TITLE
Fix FIN_WAIT_2 accumulation by draining sockets before close

### DIFF
--- a/src/conns.c
+++ b/src/conns.c
@@ -28,6 +28,7 @@
 #include "conns.h"
 #include "heap.h"
 #include "log.h"
+#include "sock.h"
 #include "stats.h"
 
 void conn_struct_init(struct conn_s *connptr) {
@@ -75,39 +76,6 @@ error_exit:
                 delete_buffer (sbuffer);
 
         return 0;
-}
-
-/*
- * Gracefully close a socket by completing the TCP close handshake.
- * Send FIN via shutdown(SHUT_WR), then drain remaining data with a
- * short timeout to receive the remote FIN.  This prevents connections
- * from getting stuck in FIN_WAIT_2 on systems that do not aggressively
- * reap orphaned sockets (e.g. OpenBSD without SO_KEEPALIVE).
- */
-static void close_socket (int fd)
-{
-        char drain[4096];
-        ssize_t n;
-        struct timeval tv;
-
-        shutdown (fd, SHUT_WR);
-
-        tv.tv_sec = 2;
-        tv.tv_usec = 0;
-        setsockopt (fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof (tv));
-
-        for (;;) {
-                n = read (fd, drain, sizeof (drain));
-                if (n > 0)
-                        continue;
-                if (n == 0)
-                        break;
-                if (errno == EINTR)
-                        continue;
-                break;
-        }
-
-        close (fd);
 }
 
 void conn_destroy_contents (struct conn_s *connptr)

--- a/src/conns.c
+++ b/src/conns.c
@@ -77,19 +77,48 @@ error_exit:
         return 0;
 }
 
+/*
+ * Gracefully close a socket by completing the TCP close handshake.
+ * Send FIN via shutdown(SHUT_WR), then drain remaining data with a
+ * short timeout to receive the remote FIN.  This prevents connections
+ * from getting stuck in FIN_WAIT_2 on systems that do not aggressively
+ * reap orphaned sockets (e.g. OpenBSD without SO_KEEPALIVE).
+ */
+static void close_socket (int fd)
+{
+        char drain[4096];
+        ssize_t n;
+        struct timeval tv;
+
+        shutdown (fd, SHUT_WR);
+
+        tv.tv_sec = 2;
+        tv.tv_usec = 0;
+        setsockopt (fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof (tv));
+
+        for (;;) {
+                n = read (fd, drain, sizeof (drain));
+                if (n > 0)
+                        continue;
+                if (n == 0)
+                        break;
+                if (errno == EINTR)
+                        continue;
+                break;
+        }
+
+        close (fd);
+}
+
 void conn_destroy_contents (struct conn_s *connptr)
 {
         assert (connptr != NULL);
 
         if (connptr->client_fd != -1)
-                if (close (connptr->client_fd) < 0)
-                        log_message (LOG_INFO, "Client (%d) close message: %s",
-                                     connptr->client_fd, strerror (errno));
+                close_socket (connptr->client_fd);
         connptr->client_fd = -1;
         if (connptr->server_fd != -1)
-                if (close (connptr->server_fd) < 0)
-                        log_message (LOG_INFO, "Server (%d) close message: %s",
-                                     connptr->server_fd, strerror (errno));
+                close_socket (connptr->server_fd);
         connptr->server_fd = -1;
 
         if (connptr->cbuffer)

--- a/src/reqs.c
+++ b/src/reqs.c
@@ -1281,6 +1281,7 @@ static void relay_connection (struct conn_s *connptr)
                 if (write_buffer (connptr->server_fd, connptr->cbuffer) < 0)
                         break;
         }
+        shutdown (connptr->server_fd, SHUT_WR);
 
         return;
 }

--- a/src/sock.c
+++ b/src/sock.c
@@ -213,6 +213,43 @@ int opensock (const char *host, int port, const char *bind_to)
 }
 
 /*
+ * Gracefully close a socket by completing the TCP close handshake.
+ * Send FIN via shutdown(SHUT_WR), then drain remaining data until
+ * the remote FIN arrives (read returns 0).  This keeps the fd open
+ * until both sides have exchanged FINs, preventing the socket from
+ * being orphaned in FIN_WAIT_2.
+ *
+ * Without this, close() orphans the socket while still in FIN_WAIT_2.
+ * Linux reaps orphaned FIN_WAIT_2 via net.ipv4.tcp_fin_timeout, but
+ * OpenBSD has no equivalent, so they persist indefinitely.
+ */
+void close_socket (int fd)
+{
+        char drain[4096];
+        ssize_t n;
+        struct timeval tv;
+
+        shutdown (fd, SHUT_WR);
+
+        tv.tv_sec = 10;
+        tv.tv_usec = 0;
+        setsockopt (fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof (tv));
+
+        for (;;) {
+                n = read (fd, drain, sizeof (drain));
+                if (n > 0)
+                        continue;
+                if (n == 0)
+                        break;
+                if (errno == EINTR)
+                        continue;
+                break;
+        }
+
+        close (fd);
+}
+
+/*
  * Set the socket to non blocking -rjkaes
  */
 int socket_nonblocking (int sock)

--- a/src/sock.h
+++ b/src/sock.h
@@ -53,6 +53,7 @@ union sockaddr_union {
 extern int opensock (const char *host, int port, const char *bind_to);
 extern int listen_sock (const char *addr, uint16_t port, sblist* listen_fds);
 
+extern void close_socket (int fd);
 extern int socket_nonblocking (int sock);
 extern int socket_blocking (int sock);
 


### PR DESCRIPTION
## Problem

On OpenBSD, proxied connections accumulate in FIN_WAIT_2 state and are
never reaped.  When enough build up the proxy stalls.

```
tcp 0 0 172.20.66.101.8080 172.20.66.3.17914 FIN_WAIT_2
tcp 0 0 172.20.66.101.8080 172.20.66.3.13047 FIN_WAIT_2
tcp 0 0 172.20.66.101.8080 172.20.66.3.30194 FIN_WAIT_2
...
```

After `shutdown(client_fd, SHUT_WR)` sends a FIN to the client,
`conn_destroy_contents()` calls `close()` without waiting for
the remote FIN.  The socket is orphaned while still in FIN_WAIT_2.

On Linux this is masked by `net.ipv4.tcp_fin_timeout` (default 60 s)
which aggressively reaps orphaned FIN_WAIT_2 sockets.  OpenBSD has no
equivalent aggressive timeout, so without `SO_KEEPALIVE` these sockets
persist indefinitely.

The problem also affects the timeout and poll-error return paths in
`relay_connection()`, which skip `shutdown()` entirely and go
straight to `close()`.

## Fix

- Add `close_socket()` helper in `conns.c` that performs a proper
  TCP close handshake: `shutdown(SHUT_WR)`, drain with a 2-second
  `SO_RCVTIMEO`, then `close()`.  This gives the remote side time
  to send its FIN before the socket is orphaned.
- Use it in `conn_destroy_contents()` for both client and server
  file descriptors, covering all exit paths from `relay_connection()`.
- Add the missing `shutdown(server_fd, SHUT_WR)` in
  `relay_connection()` after flushing remaining data to the upstream
  server.

## Testing

Tested on OpenBSD.  After the fix, connections transition through
TIME_WAIT normally instead of accumulating in FIN_WAIT_2.