### PR TITLE
reqs: fix case-sensitive matching of "chunked"

### DIFF
--- a/src/reqs.c
+++ b/src/reqs.c
@@ -812,7 +812,7 @@ static int is_chunked_transfer (pseudomap *hashofheaders)
 {
         char *data;
         data = pseudomap_find (hashofheaders, "transfer-encoding");
-        return data ? !strcmp (data, "chunked") : 0;
+        return data ? !strcasecmp (data, "chunked") : 0;
 }
 
 /*


### PR DESCRIPTION
the chunked transfer encoding needs to be matched in a case- insensitive manner.

closes #604