### PR TITLE
reqs: improve stathost detection

### DIFF
--- a/src/reqs.c
+++ b/src/reqs.c
@@ -316,25 +316,15 @@ static int send_connect_method_response (struct conn_s *connptr)
                                       connptr->protocol.minor);
 }
 
-/* determines whether an URL stripped of the initial http:// OR a host header
-   requests the configured stathost. */
-static int is_stathost(char* host) {
-        char *p, *q;
+/* determine whether a hostname with optional trailing colon/port is the
+   stathost */
+static int is_stathost(const char* host) {
+        const char *p = host, *q;
         if (!host || !config->stathost) return 0;
-        p = strchr (host, '@'); /* skip over username/password if existing */
-        if (p) ++p;
-        else p = host;
-        q = strrchr (p, ':'); /* find either the first ':' pointing to port */
-        if (!q) q = strchr (p, '/'); /* or the first / in an url */
-        if (!q) q = p + strlen (p);   /* else the hostname ends at \0 */
-        if (q - p != (long)strlen (config->stathost)) return 0;
+        q = strchr (p, ':');		/* find ':' pointing to port */
+        if (!q) q = p + strlen (p);	/* else the hostname ends at \0 */
+        if (q - p != (long) strlen (config->stathost)) return 0;
         return !strncasecmp (config->stathost, p, q - p);
-}
-
-static int check_stathost(char* hosts_header, char *url) {
-        /* if the Host: header was passed it's the only source of truth */
-        if (hosts_header) return is_stathost(hosts_header);
-        return !strncasecmp (url, "http://", 7) && is_stathost(url + 7);
 }
 
 /*
@@ -408,7 +398,8 @@ BAD_REQUEST_ERROR:
         /*
          * Check to see if they're requesting the stat host
          */
-        if (check_stathost (pseudomap_find (hashofheaders, "host"), url)) {
+        if (is_stathost (pseudomap_find (hashofheaders, "host"))) {
+got_stathost:
                 log_message (LOG_NOTICE, "Request for the stathost.");
                 connptr->show_stats = TRUE;
                 goto fail;
@@ -527,6 +518,9 @@ BAD_REQUEST_ERROR:
                 }
         }
 #endif
+        /* check whether hostname from url is the stathost */
+        if (is_stathost (request->host))
+                goto got_stathost;
 
         safefree (url);
         return request;

--- a/src/reqs.c
+++ b/src/reqs.c
@@ -316,6 +316,27 @@ static int send_connect_method_response (struct conn_s *connptr)
                                       connptr->protocol.minor);
 }
 
+/* determines whether an URL stripped of the initial http:// OR a host header
+   requests the configured stathost. */
+static int is_stathost(char* host) {
+        char *p, *q;
+        if (!host || !config->stathost) return 0;
+        p = strchr (host, '@'); /* skip over username/password if existing */
+        if (p) ++p;
+        else p = host;
+        q = strrchr (p, ':'); /* find either the first ':' pointing to port */
+        if (!q) q = strchr (p, '/'); /* or the first / in an url */
+        if (!q) q = p + strlen (p);   /* else the hostname ends at \0 */
+        if (q - p != (long)strlen (config->stathost)) return 0;
+        return !strncasecmp (config->stathost, p, q - p);
+}
+
+static int check_stathost(char* hosts_header, char *url) {
+        /* if the Host: header was passed it's the only source of truth */
+        if (hosts_header) return is_stathost(hosts_header);
+        return !strncasecmp (url, "http://", 7) && is_stathost(url + 7);
+}
+
 /*
  * Break the request line apart and figure out where to connect and
  * build a new request line. Finally connect to the remote server.
@@ -381,6 +402,15 @@ BAD_REQUEST_ERROR:
                 indicate_http_error (connptr, 400, "Bad Request",
                                      "detail", "Request has an invalid format",
                                      "url", url, NULL);
+                goto fail;
+        }
+
+        /*
+         * Check to see if they're requesting the stat host
+         */
+        if (check_stathost (pseudomap_find (hashofheaders, "host"), url)) {
+                log_message (LOG_NOTICE, "Request for the stathost.");
+                connptr->show_stats = TRUE;
                 goto fail;
         }
 
@@ -498,18 +528,7 @@ BAD_REQUEST_ERROR:
         }
 #endif
 
-
-        /*
-         * Check to see if they're requesting the stat host
-         */
-        if (config->stathost && strcmp (config->stathost, request->host) == 0) {
-                log_message (LOG_NOTICE, "Request for the stathost.");
-                connptr->show_stats = TRUE;
-                goto fail;
-        }
-
         safefree (url);
-
         return request;
 
 fail:

--- a/src/reqs.c
+++ b/src/reqs.c
@@ -318,8 +318,10 @@ static int send_connect_method_response (struct conn_s *connptr)
 
 /* determine whether a hostname with optional trailing colon/port is the
    stathost */
-static int is_stathost(const char* host) {
-        const char *p = config->stathost, *q = host;
+static int is_stathost (const char* host)
+{
+        const char *p = config->stathost;
+        const char *q = host;
         if (!p || !q) return 0;
         while (*p && *(p++) == *(q++));
         return *p == 0 && (*q == 0 || *q == ':');

--- a/src/reqs.c
+++ b/src/reqs.c
@@ -319,12 +319,10 @@ static int send_connect_method_response (struct conn_s *connptr)
 /* determine whether a hostname with optional trailing colon/port is the
    stathost */
 static int is_stathost(const char* host) {
-        const char *p = host, *q;
-        if (!host || !config->stathost) return 0;
-        q = strchr (p, ':');		/* find ':' pointing to port */
-        if (!q) q = p + strlen (p);	/* else the hostname ends at \0 */
-        if (q - p != (long) strlen (config->stathost)) return 0;
-        return !strncasecmp (config->stathost, p, q - p);
+        const char *p = config->stathost, *q = host;
+        if (!p || !q) return 0;
+        while (*p && *(p++) == *(q++));
+        return *p == 0 && (*q == 0 || *q == ':');
 }
 
 /*
@@ -1643,7 +1641,7 @@ void handle_connection (struct conn_s *connptr, union sockaddr_union* addr)
 
                 if (!authstring && config->stathost) {
                         authstring = pseudomap_find (hashofheaders, "host");
-                        if (authstring && !strncmp(authstring, config->stathost, strlen(config->stathost))) {
+                        if (authstring && is_stathost(authstring)) {
                                 authstring = pseudomap_find (hashofheaders, "authorization");
                                 stathost_connect = 1;
                         } else authstring = 0;


### PR DESCRIPTION
- check stathost before transparent proxy check, else stathost might be misdetected as a trans host request.
- rather than just the URL in the request, check "Host" header first. if it exists, we only check it for a match, else we extract the host from the url and check that. for both cases we need to exclude trailing port specs, and a trailing path in case it's an URL.

this should make it easier to access the stathost, for example by injecting a host header into a curl command line with -H: $ curl -H "Host: tinyproxy.stats" 127.0.0.1:8080

the stathost can also be specified as an ip address, e.g. Stathost "127.0.0.10" + a separate Listen statement for that ip. in such a case e.g.
$ curl http://127.0.0.10:8080
would work too, even if curl didn't add a Host header (but it does anyway).