### PR TITLE
Fix FIN_WAIT_2 accumulation by draining sockets before close

### DIFF
--- a/src/conns.c
+++ b/src/conns.c
@@ -28,6 +28,7 @@
 #include "conns.h"
 #include "heap.h"
 #include "log.h"
+#include "sock.h"
 #include "stats.h"
 
 void conn_struct_init(struct conn_s *connptr) {
@@ -82,14 +83,10 @@ void conn_destroy_contents (struct conn_s *connptr)
         assert (connptr != NULL);
 
         if (connptr->client_fd != -1)
-                if (close (connptr->client_fd) < 0)
-                        log_message (LOG_INFO, "Client (%d) close message: %s",
-                                     connptr->client_fd, strerror (errno));
+                close_socket (connptr->client_fd);
         connptr->client_fd = -1;
         if (connptr->server_fd != -1)
-                if (close (connptr->server_fd) < 0)
-                        log_message (LOG_INFO, "Server (%d) close message: %s",
-                                     connptr->server_fd, strerror (errno));
+                close_socket (connptr->server_fd);
         connptr->server_fd = -1;
 
         if (connptr->cbuffer)

--- a/src/reqs.c
+++ b/src/reqs.c
@@ -1259,6 +1259,7 @@ static void relay_connection (struct conn_s *connptr)
                 if (write_buffer (connptr->server_fd, connptr->cbuffer) < 0)
                         break;
         }
+        shutdown (connptr->server_fd, SHUT_WR);
 
         return;
 }

--- a/src/sock.c
+++ b/src/sock.c
@@ -212,6 +212,40 @@ int opensock (const char *host, int port, const char *bind_to)
         return sockfd;
 }
 
+/*
+ * Gracefully close a socket by completing the TCP close handshake.
+ *
+ * shutdown(SHUT_WR) sends our FIN while the fd stays open, then we
+ * drain whatever the peer still sends until read() returns 0, which
+ * signals that the peer's FIN has arrived.  Only then do we close().
+ * By that point the four-way handshake is complete and the socket
+ * moves to TIME_WAIT, which the kernel reaps on its own.
+ *
+ * Calling close() on a socket still in FIN_WAIT_2 orphans it.  Linux
+ * reaps orphaned FIN_WAIT_2 sockets via net.ipv4.tcp_fin_timeout, but
+ * OpenBSD has no equivalent, so they accumulate until the proxy
+ * stalls.  See RFC 793 sec. 3.5 and Stevens, UNIX Network
+ * Programming Vol. 1 sec. 6.6.
+ */
+void close_socket (int fd)
+{
+        char drain[4096];
+        ssize_t n;
+        struct timeval tv;
+
+        shutdown (fd, SHUT_WR);
+
+        tv.tv_sec = 10;
+        tv.tv_usec = 0;
+        setsockopt (fd, SOL_SOCKET, SO_RCVTIMEO, (void *) &tv, sizeof (tv));
+
+        do {
+                n = read (fd, drain, sizeof (drain));
+        } while (n > 0 || (n < 0 && errno == EINTR));
+
+        close (fd);
+}
+
 /**
  * Try to listen on one socket based on the addrinfo
  * as returned from getaddrinfo.

--- a/src/sock.h
+++ b/src/sock.h
@@ -52,6 +52,7 @@ union sockaddr_union {
 
 extern int opensock (const char *host, int port, const char *bind_to);
 extern int listen_sock (const char *addr, uint16_t port, sblist* listen_fds);
+extern void close_socket (int fd);
 
 extern void set_socket_timeout(int fd);
 


### PR DESCRIPTION
Re-opens #600 with fresh code on top of current master (the original branch was deleted during a repo cleanup). @rofl0r had said he planned to merge it after reading up on the close semantics — this is the same fix, rebased and tidied up.

### Problem

On OpenBSD, proxied connections accumulate in FIN_WAIT_2 and are never reaped. Once enough build up, the proxy stalls.

```
tcp 0 0 172.20.66.101.8080 172.20.66.3.17914 FIN_WAIT_2
tcp 0 0 172.20.66.101.8080 172.20.66.3.13047 FIN_WAIT_2
...
```

After `relay_connection()` sends a FIN with `shutdown(SHUT_WR)`, `conn_destroy_contents()` calls `close()` without waiting for the peer's FIN, orphaning the socket while it is still in FIN_WAIT_2. The idle-timeout and poll-error return paths are worse: they skip `shutdown()` entirely. On Linux this is masked by `net.ipv4.tcp_fin_timeout` (default 60s); OpenBSD has no equivalent, so they persist indefinitely.

### Why a read after shutdown (re: @rofl0r's question on #600)

It isn't that a read is "required" after shutdown in general — it's the mechanism to detect the peer's FIN so we keep the fd open until the four-way handshake finishes. `shutdown(SHUT_WR)` sends our FIN while the fd stays open; `read()` returning 0 means the peer's FIN arrived and the socket moved to TIME_WAIT. Closing then is harmless because TIME_WAIT is self-limiting (2×MSL). Closing earlier, in FIN_WAIT_2, orphans the socket and leaves its fate to a kernel timeout OpenBSD doesn't have. References: RFC 793 §3.5 and Stevens, *UNIX Network Programming* Vol. 1 §6.6.

### Fix

- Add `close_socket()` in `sock.c`: `shutdown(SHUT_WR)`, drain the peer with a 10s `SO_RCVTIMEO` until `read()` returns 0, then `close()`. It's self-contained, so it also covers the timeout/poll-error paths that previously skipped `shutdown()`. The 10s cap means a peer that never sends its FIN can't tie up a worker thread indefinitely.
- Use it for both descriptors in `conn_destroy_contents()`.
- Add the matching `shutdown(server_fd, SHUT_WR)` in `relay_connection()`, symmetric with the existing client-side shutdown, so the upstream gets its FIN promptly.

### Testing

Tested on OpenBSD: connections transition through TIME_WAIT normally instead of accumulating in FIN_WAIT_2. Builds cleanly on Linux with no new warnings.
