### PR TITLE
reqs: fix mem leak in reverse proxy redirect case

### DIFF
--- a/src/reqs.c
+++ b/src/reqs.c
@@ -423,6 +423,7 @@ got_stathost:
                                 char buf[PATH_MAX];
                                 snprintf (buf, sizeof buf, "Location: %s\r\n", reverse_url);
                                 send_http_headers (connptr, 301, "Moved Permanently", buf);
+                                safefree (reverse_url);
                                 goto fail;
                         }
                         safefree (url);


### PR DESCRIPTION
Reported-by: Qwen3.6-35B-A3B-Uncensored-HauhauCS-MTP-Q4_K_P.gguf