### PR TITLE
fix fail https requests without connect

### DIFF
--- a/src/transparent-proxy.c
+++ b/src/transparent-proxy.c
@@ -64,7 +64,8 @@ do_transparent_proxy (struct conn_s *connptr, pseudomap *hashofheaders,
 
         if (strncmp(*url, "https://", 7) == 0) {
                 log_message (LOG_ERR,
-                             "process_request: cannot HTTPS for %d",
+                             "process_request: unexpected https as destination "
+                             "protocol for %d",
                              connptr->client_fd);
                 indicate_http_error (connptr, 400, "Bad Request",
                                      "detail", "You tried to connect to a "

--- a/src/transparent-proxy.c
+++ b/src/transparent-proxy.c
@@ -62,6 +62,17 @@ do_transparent_proxy (struct conn_s *connptr, pseudomap *hashofheaders,
         size_t ulen = strlen (*url);
         size_t i;
 
+        if (strncmp(*url, "https://", 7) == 0) {
+                log_message (LOG_ERR,
+                             "process_request: cannot HTTPS for %d",
+                             connptr->client_fd);
+                indicate_http_error (connptr, 400, "Bad Request",
+                                     "detail", "You tried to connect to a "
+                                     "HTTPS destination. Use CONNECT instead.",
+                                     "url", *url, NULL);
+                return 0;
+        }
+
         data = pseudomap_find (hashofheaders, "host");
         if (!data) {
                 union sockaddr_union dest_addr;


### PR DESCRIPTION
tinyproxy should reject direct proxy requests to HTTPS servers (e.g. `GET https://example.com`) as clients are expected to use CONNECT instead.

The issue was reported initially in #284 