### PR TITLE
reqs: remove trailing whitespace from header names

### DIFF
--- a/src/reqs.c
+++ b/src/reqs.c
@@ -646,10 +646,12 @@ add_header_to_connection (pseudomap *hashofheaders, char *header, size_t len)
                 return 0; /* just skip invalid header, do not give error */
 
         /* Remove any trailing whitespace before colon */
-        p = sep - 1;
-        while (p >= header && (*p == ' ' || *p == '\t'))
-                *(p--) = '\0';
-        if (p <= header)
+        if (sep == header)
+                return 0;
+        p = sep;
+        while (p > header && (p[-1] == ' ' || p[-1] == '\t'))
+                *--p = '\0';
+        if (*header == '\0')
                 return 0;
 
         /* Blank out colons, spaces, and tabs. */

--- a/src/reqs.c
+++ b/src/reqs.c
@@ -636,21 +636,25 @@ check_duplicate_header (pseudomap *hashofheaders, char *header, const char* kw)
 static int
 add_header_to_connection (pseudomap *hashofheaders, char *header, size_t len)
 {
-        char *sep;
+        char *sep, *p;
 
         /* Get rid of the new line and return at the end */
-        len -= chomp (header, len);
+        (void) chomp (header, len);
 
         sep = strchr (header, ':');
         if (!sep)
                 return 0; /* just skip invalid header, do not give error */
 
+        /* Remove any trailing whitespace before colon */
+        p = sep - 1;
+        while (p >= header && (*p == ' ' || *p == '\t'))
+                *(p--) = '\0';
+        if (p <= header)
+                return 0;
+
         /* Blank out colons, spaces, and tabs. */
         while (*sep == ':' || *sep == ' ' || *sep == '\t')
                 *sep++ = '\0';
-
-        /* Calculate the new length of just the data */
-        len -= sep - header - 1;
 
         /* prevent multiple CL/TE headers from being inserted */
         if (check_duplicate_header(hashofheaders, header, "content-length") ||


### PR DESCRIPTION
a header line like "Content-Length : 42" was split into "Content-Length " and "42", leaving the trailing whitespace and allowing an attacker to forward multiple content-length or transfer-encoding headers, circumventing the existing request-smuggling guards.

closes #623